### PR TITLE
IN-234 add integrations for s3

### DIFF
--- a/terraform/environment/modules/lambda/iam.tf
+++ b/terraform/environment/modules/lambda/iam.tf
@@ -1,5 +1,5 @@
 resource "aws_iam_role" "lambda_role" {
-  name_prefix        = "lambda-${var.environment}-"
+  name               = local.lambda
   assume_role_policy = data.aws_iam_policy_document.lambda_assume.json
   lifecycle {
     create_before_destroy = true
@@ -51,6 +51,15 @@ data "aws_iam_policy_document" "lambda" {
     resources = ["*"]
     actions = [
       "secretsmanager:GetSecretValue"
+    ]
+  }
+
+  statement {
+    sid       = "allowAssumeAccess"
+    effect    = "Allow"
+    resources = ["arn:aws:iam::${var.account.digideps_account_id}:role/integrations-s3-read-${var.account.account_mapping}"]
+    actions = [
+      "sts:AssumeRole"
     ]
   }
 }

--- a/terraform/environment/terraform.tfvars.json
+++ b/terraform/environment/terraform.tfvars.json
@@ -7,6 +7,7 @@
         "arn:aws:iam::248804316466:root",
         "arn:aws:iam::288342028542:root"
       ],
+      "digideps_account_id": "248804316466",
       "is_production": "false",
       "opg_hosted_zone": "dev.deputy-reporting.api.opg.service.justice.gov.uk",
       "session_data": "publicapi@opgtest.com",
@@ -22,6 +23,7 @@
         "arn:aws:iam::454262938596:role/front.preproduction",
         "arn:aws:iam::454262938596:role/front.master"
       ],
+      "digideps_account_id": "454262938596",
       "is_production": "false",
       "opg_hosted_zone": "pre.deputy-reporting.api.opg.service.justice.gov.uk",
       "session_data": "opg+publicapi@digital.justice.gov.uk",
@@ -36,6 +38,7 @@
       "allowed_roles": [
         "arn:aws:iam::515688267891:role/front.production02"
       ],
+      "digideps_account_id": "515688267891",
       "is_production": "true",
       "opg_hosted_zone": "deputy-reporting.api.opg.service.justice.gov.uk",
       "session_data": "opg+publicapi@digital.justice.gov.uk",

--- a/terraform/environment/variables.tf
+++ b/terraform/environment/variables.tf
@@ -9,16 +9,17 @@ variable "management_role" {
 variable "accounts" {
   type = map(
     object({
-      account_id         = string
-      account_mapping    = string
-      allowed_roles      = list(string)
-      is_production      = string
-      logger_level       = string
-      opg_hosted_zone    = string
-      vpc_id             = string
-      session_data       = string
-      target_environment = string
-      threshold          = number
+      account_id          = string
+      account_mapping     = string
+      allowed_roles       = list(string)
+      digideps_account_id = string
+      is_production       = string
+      logger_level        = string
+      opg_hosted_zone     = string
+      vpc_id              = string
+      session_data        = string
+      target_environment  = string
+      threshold           = number
     })
   )
 }


### PR DESCRIPTION
## Purpose

As part of the move to using S3 storage refs to move documents through the lambdas, we need to give the lambda task role cross account access to the digideps S3 buckets.

## Approach

Lambda role names can't be prefixes because on the digideps side we need a hard coded value for what's being allowed to assume the role.

## Learning

NA

## Checklist

* [ ] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation where relevant
* [ ] I have added tests to prove my work
* [ ] The product team have tested these changes
