### PR TITLE
Little tidyup of tests after all the merging

### DIFF
--- a/lambda_functions/v1/integration_tests/README.md
+++ b/lambda_functions/v1/integration_tests/README.md
@@ -25,5 +25,6 @@ To run the integration tests in their entirety:
 2) Activate it: `source venv/bin/activate`
 3) Install pip requirements: `pip install -r lambda_functions/v1/requirements/dev-requirements.txt`
 4) Make sure $PYTHONPATH is set to root of directory.
-5) `cd` into integrations test folder and run `aws-vault exec identity -- python -m pytest`
+5) `cd` into integrations test folder and run `aws-vault exec identity -- python -m pytest -n2 --dist=loadfile --html=report.html --self-contained-html`
+6) Open `report.html` in a browser to see the results of the tests all laid out nicely
 

--- a/lambda_functions/v1/integration_tests/cases_new_checklist_endpoint.py
+++ b/lambda_functions/v1/integration_tests/cases_new_checklist_endpoint.py
@@ -13,7 +13,6 @@ new_submission_id = random.randint(10000, 99999)
 )
 def case_success_original_IN_112(test_config: str) -> CaseData:
 
-    print(f"Using test_config: {test_config['name']}")
     # Test Data
 
     report_id = test_config["report_id"]
@@ -58,7 +57,6 @@ def case_success_original_IN_112(test_config: str) -> CaseData:
 )
 def case_success_new_submission_IN_112(test_config: str) -> CaseData:
 
-    print(f"Using test_config: {test_config['name']}")
     # Test Data
 
     report_id = test_config["report_id"]

--- a/lambda_functions/v1/integration_tests/cases_payload_errors.py
+++ b/lambda_functions/v1/integration_tests/cases_payload_errors.py
@@ -66,8 +66,6 @@ default_checklist_payload = {
 )
 def case_reports_missing_fields(test_config: str, missing) -> CaseData:
 
-    print(f"Using test_config: {test_config['name']}")
-
     endpoint = f"clients/{test_config['case_ref']}/reports"
     url = f"{test_config['url']}/{endpoint}"
     method = "POST"
@@ -96,8 +94,6 @@ def case_reports_missing_fields(test_config: str, missing) -> CaseData:
 )
 def case_reports_empty_fields(test_config: str, missing) -> CaseData:
 
-    print(f"Using test_config: {test_config['name']}")
-
     endpoint = f"clients/{test_config['case_ref']}/reports"
     url = f"{test_config['url']}/{endpoint}"
     method = "POST"
@@ -119,8 +115,6 @@ def case_reports_empty_fields(test_config: str, missing) -> CaseData:
     missing=["attributes/submission_id", "file/name", "file/mimetype", "file/source"],
 )
 def case_suppdocs_missing_fields(test_config: str, missing) -> CaseData:
-
-    print(f"Using test_config: {test_config['name']}")
 
     report_id = test_config["report_id"]
     case_ref = test_config["case_ref"]
@@ -148,7 +142,6 @@ def case_suppdocs_missing_fields(test_config: str, missing) -> CaseData:
     missing=["attributes/submission_id", "file/name", "file/mimetype", "file/source"],
 )
 def case_suppdocs_empty_fields(test_config: str, missing) -> CaseData:
-    print(f"Using test_config: {test_config['name']}")
 
     report_id = test_config["report_id"]
     case_ref = test_config["case_ref"]
@@ -177,8 +170,6 @@ def case_suppdocs_empty_fields(test_config: str, missing) -> CaseData:
 )
 def case_checklist_missing_fields(test_config: str, missing) -> CaseData:
 
-    print(f"Using test_config: {test_config['name']}")
-
     report_id = test_config["report_id"]
     case_ref = test_config["case_ref"]
 
@@ -203,7 +194,6 @@ def case_checklist_missing_fields(test_config: str, missing) -> CaseData:
     missing=["attributes/submission_id", "file/name", "file/mimetype", "file/source"],
 )
 def case_checklist_empty_fields(test_config: str, missing) -> CaseData:
-    print(f"Using test_config: {test_config['name']}")
 
     report_id = test_config["report_id"]
     case_ref = test_config["case_ref"]
@@ -229,8 +219,6 @@ def case_checklist_empty_fields(test_config: str, missing) -> CaseData:
     missing=["attributes/submission_id", "file/name", "file/mimetype", "file/source"],
 )
 def case_checklist_update_missing_fields(test_config: str, missing) -> CaseData:
-
-    print(f"Using test_config: {test_config['name']}")
 
     report_id = test_config["report_id"]
     case_ref = test_config["case_ref"]
@@ -259,7 +247,6 @@ def case_checklist_update_missing_fields(test_config: str, missing) -> CaseData:
     missing=["attributes/submission_id", "file/name", "file/mimetype", "file/source"],
 )
 def case_checklist_update_empty_fields(test_config: str, missing) -> CaseData:
-    print(f"Using test_config: {test_config['name']}")
 
     report_id = test_config["report_id"]
     case_ref = test_config["case_ref"]

--- a/lambda_functions/v1/integration_tests/cases_reports_endpoint.py
+++ b/lambda_functions/v1/integration_tests/cases_reports_endpoint.py
@@ -8,16 +8,12 @@ from lambda_functions.v1.integration_tests.conftest import generate_file_name
 @case_name("Successful post to reports endpoint")
 def case_success_original(test_config: str) -> CaseData:
 
-    print(f"Using test_config: {test_config['name']}")
-
     # Test Data
 
     submission_id = test_config["submission_id"]
 
     endpoint = f"clients/{test_config['case_ref']}/reports"
     url = f"{test_config['url']}/{endpoint}"
-
-    print(f"url: {url}")
 
     method = "POST"
     payload = {

--- a/lambda_functions/v1/integration_tests/cases_supporting_docs_endpoint.py
+++ b/lambda_functions/v1/integration_tests/cases_supporting_docs_endpoint.py
@@ -13,11 +13,6 @@ new_submission_id = random.randint(10000, 99999)
 )
 def case_success_original(test_config: str) -> CaseData:
 
-    print(f"Using test_config: {test_config['name']}")
-    # Test Data
-
-    print(f"test_config['report_id']: {test_config['report_id']}")
-
     report_id = test_config["report_id"]
     submission_id = test_config["submission_id"]
     case_ref = test_config["case_ref"]
@@ -59,9 +54,6 @@ def case_success_original(test_config: str) -> CaseData:
     "report sent in a different submission"
 )
 def case_success_new_submission(test_config: str) -> CaseData:
-
-    print(f"Using test_config: {test_config['name']}")
-    # Test Data
 
     report_id = test_config["report_id"]
     submission_id = 54321
@@ -105,9 +97,6 @@ def case_success_new_submission(test_config: str) -> CaseData:
 )
 def case_success_new_submission_2(test_config: str) -> CaseData:
 
-    print(f"Using test_config: {test_config['name']}")
-    # Test Data
-
     report_id = test_config["report_id"]
     submission_id = 543218
     case_ref = test_config["case_ref"]
@@ -149,9 +138,6 @@ def case_success_new_submission_2(test_config: str) -> CaseData:
     "supporting doc "
 )
 def case_success_new_submission_child(test_config: str) -> CaseData:
-
-    print(f"Using test_config: {test_config['name']}")
-    # Test Data
 
     report_id = test_config["report_id"]
     submission_id = 543218

--- a/lambda_functions/v1/integration_tests/cases_update_checklist_endpoint.py
+++ b/lambda_functions/v1/integration_tests/cases_update_checklist_endpoint.py
@@ -14,9 +14,6 @@ new_submission_id = random.randint(10000, 99999)
 )
 def case_success_original_IN_112(test_config: str, sub_id: int) -> CaseData:
 
-    print(f"Using test_config: {test_config['name']}")
-    # Test Data
-
     report_id = test_config["report_id"]
     submission_id = sub_id
     case_ref = test_config["case_ref"]
@@ -26,10 +23,6 @@ def case_success_original_IN_112(test_config: str, sub_id: int) -> CaseData:
         f"clients/{case_ref}/reports/" f"{report_id}/checklists/" f"{checklist_id}"
     )
     url = f"{test_config['url']}/{endpoint}"
-
-    print(f"report_id: {report_id}")
-    print(f"submission_id: {submission_id}")
-    print(f"checklist_id: {checklist_id}")
 
     method = "PUT"
     payload = {

--- a/lambda_functions/v1/integration_tests/test_all_routes_happy_path.py
+++ b/lambda_functions/v1/integration_tests/test_all_routes_happy_path.py
@@ -12,9 +12,7 @@ from lambda_functions.v1.integration_tests import (
 from lambda_functions.v1.integration_tests.conftest import (
     send_a_request,
     is_valid_uuid,
-    create_record,
     configs_to_test,
-    update_record,
 )
 
 
@@ -35,20 +33,12 @@ def test_post_a_report(case_data: CaseDataGetter, test_config):
         url=url, method=method, payload=payload, test_config=test_config
     )
 
-    print(f"response: {response}")
-
     assert status == expected_status_code
     assert type(response) == str
     if status == 201:
         r = json.loads(response)
 
-        file_name = payload["report"]["data"]["file"]["name"]
-
         test_config["report_id"] = r["data"]["id"]
-
-        create_record(
-            returned_data=r, file_name=file_name, config_name=test_config["name"]
-        )
 
         assert r["data"]["type"] == expected_response_data["type"]
         assert is_valid_uuid(r["data"]["id"])
@@ -76,20 +66,12 @@ def test_post_a_supporting_doc(case_data: CaseDataGetter, test_config):
         url=url, method=method, payload=payload, test_config=test_config
     )
 
-    r = json.loads(response)
-    print(f"r: {r}")
-
     assert status == expected_status_code
     assert type(response) == str
     if status == 201:
         r = json.loads(response)
-        file_name = payload["supporting_document"]["data"]["file"]["name"]
 
         test_config["supp_doc_id"] = r["data"]["id"]
-
-        create_record(
-            returned_data=r, file_name=file_name, config_name=test_config["name"]
-        )
 
         assert r["data"]["type"] == expected_response_data["type"]
         assert is_valid_uuid(r["data"]["id"])
@@ -122,12 +104,7 @@ def test_post_a_new_checklist(case_data: CaseDataGetter, test_config):
     if status == 201:
         r = json.loads(response)
 
-        file_name = payload["checklist"]["data"]["file"]["name"]
         test_config["checklist_id"] = r["data"]["id"]
-
-        create_record(
-            returned_data=r, file_name=file_name, config_name=test_config["name"]
-        )
 
         assert r["data"]["type"] == expected_response_data["type"]
         assert is_valid_uuid(r["data"]["id"])
@@ -159,12 +136,6 @@ def test_post_an_updated_checklist(case_data: CaseDataGetter, test_config):
     assert type(response) == str
     if status == 200:
         r = json.loads(response)
-
-        update_record(
-            returned_data=r,
-            original_record_id=expected_response_data["original_checklist_id"],
-            config_name=test_config["name"],
-        )
 
         assert r["data"]["type"] == expected_response_data["type"]
         assert is_valid_uuid(r["data"]["id"])

--- a/lambda_functions/v1/requirements/dev-requirements.txt
+++ b/lambda_functions/v1/requirements/dev-requirements.txt
@@ -15,3 +15,5 @@ flask-lambda-python36
 pytest-env
 requests_aws4auth
 faker
+pytest-html
+pytest-xdist


### PR DESCRIPTION
## Purpose

Little bits that got lost in the big merge of IN-260

- Fixed routes with an extra /
- Added pytest-html so you can get a nice report out instead of having to use the CLI
- Consolidated test output to make the html report nicer
- Removed the bits that wrote the test data to a json file in favour of the html report
- Added pytest-xdist so the happy and sad tests can run in parallel, takes way less time (like half)


## Approach



## Learning



## Checklist

* [x] I have performed a self-review of my own code
* [x] I have added relevant logging with appropriate levels to my code
* [x] I have updated documentation where relevant
* [x] I have added tests to prove my work
* [ ] The product team have tested these changes
