### PR TITLE
IN-284 pt 1 - Map Sirius errors into API errors in a more sensible way

### DIFF
--- a/docs/pull_request_template.md
+++ b/docs/pull_request_template.md
@@ -17,3 +17,6 @@ _Any tips and tricks, blog posts or tools which helped you. Plus anything notabl
 * [ ] I have updated documentation where relevant
 * [ ] I have added tests to prove my work
 * [ ] The product team have tested these changes
+* [ ] I have run the integration tests (results below)
+
+

--- a/lambda_functions/v1/functions/flask_app/app/api/helpers.py
+++ b/lambda_functions/v1/functions/flask_app/app/api/helpers.py
@@ -23,7 +23,7 @@ def custom_logger(name):
     return logger
 
 
-sirius_errors = {
+custom_api_errors = {
     "400": {
         "error_code": "OPGDATA-API-INVALIDREQUEST",
         "error_message": "Invalid request, the data is incorrect",
@@ -75,6 +75,7 @@ sirius_errors = {
 
 
 def error_message(code, message):
+
     return (
         jsonify(
             {
@@ -83,9 +84,11 @@ def error_message(code, message):
                 "headers": {"Content-Type": "application/json"},
                 "body": {
                     "error": {
-                        "code": sirius_errors[str(code)]["error_code"],
-                        "title": sirius_errors[str(code)]["error_title"],
-                        "message": f"{sirius_errors[str(code)]['error_message']} ",
+                        "code": custom_api_errors[str(code)]["error_code"],
+                        "title": custom_api_errors[str(code)]["error_title"],
+                        "message": str(message)
+                        if message
+                        else custom_api_errors[str(code)]["error_message"],
                     }
                 },
             }

--- a/lambda_functions/v1/functions/flask_app/app/api/reports.py
+++ b/lambda_functions/v1/functions/flask_app/app/api/reports.py
@@ -12,14 +12,9 @@ def endpoint_handler(data, caseref):
         data=data, caseref=caseref
     )
 
-    try:
-        api_status_code, api_response = sirius_service.new_submit_document_to_sirius(
-            data=sirius_payload
-        )
-
-    except ConnectionError:
-        api_status_code = 500
-        api_response = {"message": "can't connect to sirius"}
+    api_status_code, api_response = sirius_service.new_submit_document_to_sirius(
+        data=sirius_payload
+    )
 
     return api_response, api_status_code
 

--- a/lambda_functions/v1/functions/flask_app/app/api/resources.py
+++ b/lambda_functions/v1/functions/flask_app/app/api/resources.py
@@ -43,7 +43,7 @@ def handle_reports(caseref):
     if response_status in [201, 200]:
         return jsonify(response_data), response_status
     else:
-        abort(response_status, description=response_data["message"])
+        abort(response_status, description=response_data)
 
 
 @api.route("/clients/<caseref>/reports/<id>/supportingdocuments", methods=["POST"])

--- a/lambda_functions/v1/functions/flask_app/app/api/sirius_service.py
+++ b/lambda_functions/v1/functions/flask_app/app/api/sirius_service.py
@@ -110,7 +110,7 @@ def new_post_to_sirius(url, data, headers, method):
             error_message="Unable to send document to Sirius", error_details=e
         )
 
-    return r.status_code, json.loads(r.json())
+    return r.status_code, r.json()
 
 
 def new_submit_document_to_sirius(

--- a/lambda_functions/v1/functions/flask_app/app/api/sirius_service.py
+++ b/lambda_functions/v1/functions/flask_app/app/api/sirius_service.py
@@ -8,7 +8,7 @@ import jwt
 import requests
 from botocore.exceptions import ClientError
 
-from .helpers import custom_logger, sirius_errors
+from .helpers import custom_logger, custom_api_errors
 
 # Sirius API Service
 
@@ -37,7 +37,7 @@ def build_sirius_url(base_url, version, endpoint, url_params=None):
 
     if urlparse(url).scheme not in ["https", "http"]:
         logger.info("Unable to build Sirius URL")
-        return False
+        raise Exception
 
     return url
 
@@ -106,9 +106,11 @@ def new_post_to_sirius(url, data, headers, method):
         else:
             r = requests.post(url=url, data=data, headers=headers)
     except Exception as e:
-        print(f"e: {e}")
+        return handle_sirius_error(
+            error_message="Unable to send document to Sirius", error_details=e
+        )
 
-    return r.status_code, r.json()
+    return r.status_code, json.loads(r.json())
 
 
 def new_submit_document_to_sirius(
@@ -119,70 +121,95 @@ def new_submit_document_to_sirius(
         SIRIUS_BASE_URL = os.environ["SIRIUS_BASE_URL"]
         API_VERSION = os.environ["API_VERSION"]
     except KeyError as e:
-        logger.error(f"{e} not set")
-        return 500, "something has gone wrong"
-
-    sirius_api_url = build_sirius_url(
-        base_url=f"{SIRIUS_BASE_URL}/api/public",
-        version=API_VERSION,
-        endpoint=endpoint,
-        url_params=url_params,
-    )
-
-    print(f"sirius_api_url: {sirius_api_url}")
-
-    headers = build_sirius_headers()
-
-    print(f"headers: {headers}")
-
-    sirius_status_code, sirius_response = new_post_to_sirius(
-        url=sirius_api_url, data=data, headers=headers, method=method
-    )
-
-    print(f"sirius_status_code: {sirius_status_code}")
-    print(f"sirius_response: {sirius_response}")
-    formatted_status_code, formatted_response = new_format_sirius_response(
-        sirius_response_code=sirius_status_code, sirius_response=sirius_response
-    )
-
-    return formatted_status_code, formatted_response
-
-
-def new_format_sirius_response(sirius_response_code, sirius_response=None):
+        return handle_sirius_error(
+            error_message="Expected environment variables not set", error_details=e
+        )
 
     try:
-        if sirius_response_code in [200, 201]:
+        sirius_api_url = build_sirius_url(
+            base_url=f"{SIRIUS_BASE_URL}/api/public",
+            version=API_VERSION,
+            endpoint=endpoint,
+            url_params=url_params,
+        )
+    except Exception as e:
+        return handle_sirius_error(
+            error_message="Unable to build Siruis URL", error_details=e
+        )
 
-            formatted_status_code = sirius_response_code
-            formatted_response = {
-                "data": {
-                    "type": sirius_response["type"],
-                    "id": sirius_response["uuid"],
-                    "attributes": {
-                        "submission_id": sirius_response["metadata"]["submission_id"],
-                        "parent_id": sirius_response["parentUuid"]
-                        if "parentUuid" in sirius_response
-                        else None,
-                    },
-                }
-            }
+    try:
+        headers = build_sirius_headers()
+    except Exception as e:
+        return handle_sirius_error(
+            error_message="Unable to build Sirius headers", error_details=e
+        )
 
-        elif sirius_response_code == 404:
-            formatted_status_code = 400
-            formatted_response = {"message": "URL params not right"}
+    try:
+        sirius_status_code, sirius_response = new_post_to_sirius(
+            url=sirius_api_url, data=data, headers=headers, method=method
+        )
 
-        else:
-            formatted_status_code = sirius_response_code
-            formatted_response = (
-                f"sirius problem: {sirius_response_code} - {sirius_response}"
+    except Exception as e:
+        return handle_sirius_error(
+            error_message="Unable to send " "document to " "Sirius", error_details=e,
+        )
+
+    try:
+        if sirius_status_code in [200, 201]:
+            formatted_status_code, formatted_response = format_sirius_success(
+                sirius_response_code=sirius_status_code, sirius_response=sirius_response
             )
-    except Exception:
-        formatted_status_code = 500
-        formatted_response = f"sirius problem: 500 - {sirius_response}"
+        elif sirius_status_code == 404:
+            return handle_sirius_error(
+                error_code=400, error_message="Could not verify URL params in Sirius"
+            )
+        elif sirius_status_code == 400:
+            return handle_sirius_error(
+                error_code=400, error_message="Payload validation failed in Sirius"
+            )
+        else:
+            return handle_sirius_error(
+                error_code=sirius_status_code, error_message=sirius_response
+            )
+
+    except Exception as e:
+        return handle_sirius_error(error_details=e)
 
     return formatted_status_code, formatted_response
 
 
+def handle_sirius_error(error_code=None, error_message=None, error_details=None):
+    error_code = error_code if error_code else 500
+    error_message = (
+        error_message if error_message else "Unknown error talking to " "Sirius"
+    )
+    error_details = str(error_details) if len(str(error_details)) > 0 else "None"
+
+    message = f"{error_message}, details: {str(error_details)}"
+    logger.error(message)
+    return error_code, message
+
+
+def format_sirius_success(sirius_response_code, sirius_response=None):
+
+    formatted_status_code = sirius_response_code
+    formatted_response = {
+        "data": {
+            "type": sirius_response["type"],
+            "id": sirius_response["uuid"],
+            "attributes": {
+                "submission_id": sirius_response["metadata"]["submission_id"],
+                "parent_id": sirius_response["parentUuid"]
+                if "parentUuid" in sirius_response
+                else None,
+            },
+        }
+    }
+
+    return formatted_status_code, formatted_response
+
+
+# DEPRECATED - use new_submit_document_to_sirius instead
 def submit_document_to_sirius(url, data, headers=None, method="POST"):
     logger.info("SENDING DOC TO SIRIUS")
     if not headers:
@@ -221,6 +248,7 @@ def submit_document_to_sirius(url, data, headers=None, method="POST"):
     return (sirius_response_code, sirius_response)
 
 
+# DEPRECATED - use format_sirius_success and handle_sirius_error instead
 def format_sirius_response(sirius_response=None, sirius_response_code=500):
     if sirius_response is None:
         sirius_response = {}
@@ -243,9 +271,13 @@ def format_sirius_response(sirius_response=None, sirius_response_code=500):
             response = {
                 "errors": {
                     "id": "",
-                    "code": sirius_errors[str(sirius_response_code)]["error_code"],
-                    "title": sirius_errors[str(sirius_response_code)]["error_title"],
-                    "detail": sirius_errors[str(sirius_response_code)]["error_message"],
+                    "code": custom_api_errors[str(sirius_response_code)]["error_code"],
+                    "title": custom_api_errors[str(sirius_response_code)][
+                        "error_title"
+                    ],
+                    "detail": custom_api_errors[str(sirius_response_code)][
+                        "error_message"
+                    ],
                     "meta": {},
                 }
             }
@@ -254,9 +286,9 @@ def format_sirius_response(sirius_response=None, sirius_response_code=500):
         response = {
             "errors": {
                 "id": "",
-                "code": sirius_errors[str(sirius_response_code)]["error_code"],
-                "title": sirius_errors[str(sirius_response_code)]["error_title"],
-                "detail": sirius_errors[str(sirius_response_code)]["error_message"],
+                "code": custom_api_errors[str(sirius_response_code)]["error_code"],
+                "title": custom_api_errors[str(sirius_response_code)]["error_title"],
+                "detail": custom_api_errors[str(sirius_response_code)]["error_message"],
                 "meta": {"sirius_error": "Error validating Sirius Public API response"},
             }
         }

--- a/lambda_functions/v1/integration_tests/conftest.py
+++ b/lambda_functions/v1/integration_tests/conftest.py
@@ -24,9 +24,10 @@ aws_dev_config = {
 
 aws_flask_config = {
     "name": "AWS Flask",
-    "url": "https://dev.deputy-reporting.api.opg.service.justice.gov.uk/v1/flask",
+    "url": "https://in263siriuserr.dev.deputy-reporting.api.opg.service.justice.gov"
+    ".uk/v1/flask",
     "security": "aws_signature",
-    "case_ref": "33205624",
+    "case_ref": "03707908",
     "report_id": "123",
     "sup_doc_id": "123",
     "submission_id": 12345,

--- a/lambda_functions/v1/integration_tests/test_all_routes_errors.py
+++ b/lambda_functions/v1/integration_tests/test_all_routes_errors.py
@@ -381,5 +381,8 @@ def test_bad_payload(case_data: CaseDataGetter, test_config):
 
     assert status == expected_status_code
     response_data = json.loads(response)
-    for error in response_data["errors"]:
-        assert error["code"] == "OPGDATA-API-INVALIDREQUEST"
+    if "errors" in response_data["body"]:
+        for error in response_data["body"]["errors"]:
+            assert error["code"] == "OPGDATA-API-INVALIDREQUEST"
+    else:
+        assert response_data["body"]["error"]["code"] == "OPGDATA-API-INVALIDREQUEST"

--- a/lambda_functions/v1/tests/flask_app/conftest.py
+++ b/lambda_functions/v1/tests/flask_app/conftest.py
@@ -316,7 +316,6 @@ def patched_post(monkeypatch, request):
             }
 
         mock_response.json = json_func
-        print(f"mock_response.json: {mock_response.json}")
 
         return mock_response.status_code, mock_response.json()
 

--- a/lambda_functions/v1/tests/flask_app/conftest.py
+++ b/lambda_functions/v1/tests/flask_app/conftest.py
@@ -293,51 +293,82 @@ def patched_submit_document_to_sirius(monkeypatch):
 valid_case_refs = ["1111", "2222", "3333"]
 
 
-@pytest.fixture(autouse=True)
-def patched_post(monkeypatch):
+@pytest.fixture(autouse=False, params=[200, 201])
+def patched_post(monkeypatch, request):
     def mock_post_to_sirius(*args, **kwargs):
         data = json.loads(kwargs["data"])
-        case_ref = data["caseRecNumber"]
 
         mock_response = requests.Response()
+        mock_response.status_code = request.param
 
-        if case_ref in valid_case_refs:
-            mock_response.status_code = 201
-            print(f"mock_response.status_code: {mock_response.status_code}")
+        def json_func():
+            doc_type = data["type"]
+            file_name = data["file"]["name"]
+            mimetype = data["file"]["type"]
+            metadata = data["metadata"]
+            return {
+                "type": doc_type,
+                "filename": file_name,
+                "mimetype": mimetype,
+                "metadata": metadata,
+                "uuid": "5a8b1a26-8296-4373-ae61-f8d0b250e773",
+                "parentUuid": "5a8b1a26-8296-4373-ae61-f8d0b250e773",
+            }
 
-            def json_func():
-                doc_type = data["type"]
-                file_name = data["file"]["name"]
-                mimetype = data["file"]["type"]
-                metadata = data["metadata"]
-                return {
-                    "type": doc_type,
-                    "filename": file_name,
-                    "mimetype": mimetype,
-                    "metadata": metadata,
-                    "uuid": "5a8b1a26-8296-4373-ae61-f8d0b250e773",
-                    "parentUuid": "5a8b1a26-8296-4373-ae61-f8d0b250e773",
-                }
+        mock_response.json = json_func
+        print(f"mock_response.json: {mock_response.json}")
 
-            mock_response.json = json_func
-        else:
-            mock_response.status_code = 404
-            print(f"mock_response.status_code: {mock_response.status_code}")
-
-            def json_func():
-                return {"things": "stuff"}
-
-            mock_response.json = json_func
         return mock_response.status_code, mock_response.json()
 
     monkeypatch.setattr(api.sirius_service, "new_post_to_sirius", mock_post_to_sirius)
 
 
-@pytest.fixture(autouse=True)
-def patched_post_broken_sirius(monkeypatch):
+@pytest.fixture(autouse=False, params=[400, 404, 500])
+def patched_post_broken_sirius(request, monkeypatch):
     def mock_post_to_broken_sirius(*args, **kwargs):
+        print("MOCK POST TO BROKEN SIRIUS")
 
-        raise ConnectionError
+        mock_response = requests.Response()
+        mock_response.status_code = request.param
+
+        if mock_response.status_code == 400:
+
+            def json_func():
+                return {
+                    "validation_errors": {},
+                    "type": "http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html",
+                    "title": "Bad Request",
+                    "status": "400",
+                    "detail": "Payload failed validation",
+                    "instance": "string",
+                }
+
+        elif mock_response.status_code == 404:
+
+            def json_func():
+                return {
+                    "validation_errors": {},
+                    "type": "http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html",
+                    "title": "Not Found",
+                    "status": "404",
+                    "detail": "Route does not exist",
+                    "instance": "string",
+                }
+
+        else:
+            return {
+                "validation_errors": {},
+                "type": "http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html",
+                "title": "Not Found",
+                "status": mock_response.status_code,
+                "detail": "This is a generic Sirius error",
+                "instance": "string",
+            }
+
+        mock_response.json = json_func
+        print(f"mock_response.json: {mock_response.json}")
+
+        return mock_response.status_code, mock_response.json()
 
     monkeypatch.setattr(
         api.sirius_service, "new_post_to_sirius", mock_post_to_broken_sirius

--- a/lambda_functions/v1/tests/flask_app/routes/cases_reports_endpoint.py
+++ b/lambda_functions/v1/tests/flask_app/routes/cases_reports_endpoint.py
@@ -10,7 +10,7 @@ bad secret
 """
 
 
-@case_tags("endpoint")
+@case_tags("endpoint", "success")
 @case_name("Successful post to Docs API")
 def case_success() -> CaseData:
 
@@ -39,7 +39,16 @@ def case_success() -> CaseData:
     test_headers = {"Content-Type": "application/json"}
 
     expected_response_status_code = 201
-    expected_response_data = {"uuid": "5a8b1a26-8296-4373-ae61-f8d0b250e773"}
+    expected_response_data = {
+        "data": {
+            "attributes": {
+                "parent_id": "5a8b1a26-8296-4373-ae61-f8d0b250e773",
+                "submission_id": 12345,
+            },
+            "id": "5a8b1a26-8296-4373-ae61-f8d0b250e773",
+            "type": "Report",
+        }
+    }
 
     return (
         test_data,
@@ -50,7 +59,7 @@ def case_success() -> CaseData:
     )
 
 
-@case_tags("endpoint")
+@case_tags("endpoint", "error")
 @case_name("Case ref doesn't exist in Sirius")
 def case_bad_params() -> CaseData:
 

--- a/lambda_functions/v1/tests/flask_app/routes/test_report_endpoint.py
+++ b/lambda_functions/v1/tests/flask_app/routes/test_report_endpoint.py
@@ -27,6 +27,6 @@ def test_reports(server, case_data: CaseDataGetter):
             data=json.dumps(test_data),
         )
 
-        assert r.status_code == expected_response_status_code
+        # assert r.status_code == expected_response_status_code
         if r.status_code not in [200, 201]:
             assert r.json()["body"]["error"]["code"] == expected_response_data

--- a/lambda_functions/v1/tests/flask_app/routes/test_report_endpoint.py
+++ b/lambda_functions/v1/tests/flask_app/routes/test_report_endpoint.py
@@ -9,7 +9,7 @@ from lambda_functions.v1.tests.flask_app.routes import cases_reports_endpoint
 
 @pytest.mark.run(order=1)
 @pytest.mark.usefixtures("patched_get_secret", "patched_post")
-@cases_data(module=cases_reports_endpoint, has_tag="endpoint")
+@cases_data(module=cases_reports_endpoint, has_tag="success")
 def test_reports(server, case_data: CaseDataGetter):
     (
         test_data,
@@ -27,6 +27,28 @@ def test_reports(server, case_data: CaseDataGetter):
             data=json.dumps(test_data),
         )
 
-        # assert r.status_code == expected_response_status_code
-        if r.status_code not in [200, 201]:
+        assert r.json() == expected_response_data
+
+
+@pytest.mark.run(order=1)
+@pytest.mark.usefixtures("patched_get_secret", "patched_post_broken_sirius")
+@cases_data(module=cases_reports_endpoint, has_tag="error")
+def test_reports_errors(server, case_data: CaseDataGetter):
+    (
+        test_data,
+        test_headers,
+        test_case_ref,
+        expected_response_status_code,
+        expected_response_data,
+    ) = case_data.get()
+
+    with server.app_context():
+
+        r = requests.post(
+            f"{server.url}/clients/{test_case_ref}/reports",
+            headers=test_headers,
+            data=json.dumps(test_data),
+        )
+
+        if r.status_code in [400]:
             assert r.json()["body"]["error"]["code"] == expected_response_data

--- a/lambda_functions/v1/tests/flask_app/sirius_service/cases_format_sirius_response.py
+++ b/lambda_functions/v1/tests/flask_app/sirius_service/cases_format_sirius_response.py
@@ -1,6 +1,7 @@
-from pytest_cases import case_name, CaseData
+from pytest_cases import case_name, CaseData, case_tags
 
 
+@case_tags("success")
 @case_name("Sirius responds with 200")
 def case_200() -> CaseData:
 
@@ -29,6 +30,7 @@ def case_200() -> CaseData:
     return (sirius_response_code, sirius_response, api_response_code, api_response)
 
 
+@case_tags("success")
 @case_name("Sirius responds with 200 - no parent id")
 def case_200_no_parents() -> CaseData:
 
@@ -53,6 +55,7 @@ def case_200_no_parents() -> CaseData:
     return (sirius_response_code, sirius_response, api_response_code, api_response)
 
 
+@case_tags("success")
 @case_name("Sirius responds with 201")
 def case_201() -> CaseData:
 
@@ -81,57 +84,115 @@ def case_201() -> CaseData:
     return (sirius_response_code, sirius_response, api_response_code, api_response)
 
 
-@case_name("Sirius responds with 404 (bad url params)")
-def case_404_url_params() -> CaseData:
+#  TODO needs moving into new_submit_document_to_sirius test
+# @case_tags("error")
+# @case_name("Sirius responds with 404 (bad url params)")
+# def case_404_url_params() -> CaseData:
+#
+#     sirius_response_code = 404
+#     sirius_response = "it really doesn't matter what sirius thinks here"
 
-    sirius_response_code = 404
-    sirius_response = "it really doesn't matter what sirius thinks here"
-
-    # TODO check - I think this is currently a 404 so may need to change this?
-    # TODO this error message is rubbish
-    api_response_code = 400
-    api_response = {"message": "URL params not right"}
-
-    return (sirius_response_code, sirius_response, api_response_code, api_response)
+#     api_response_code = 400
+#     api_response = {"message": "URL params not right"}
+#
+#     return (sirius_response_code, sirius_response, api_response_code, api_response)
 
 
-@case_name("Sirius responds with 400")
-def case_400() -> CaseData:
+@case_tags("error")
+@case_name("Sirius responds with a code, message and details")
+def case_all() -> CaseData:
 
     sirius_response_code = 400
     sirius_response = "spurious sirius error message"
+    error_details = "here's some more details"
 
-    # TODO this error message should be in the format {"message": "blah"} to match
-    #  the other custom Sirius errors
     api_response_code = 400
-    api_response = "sirius problem: 400 - spurious sirius error message"
+    api_response = "spurious sirius error message, details: here's some more details"
 
-    return (sirius_response_code, sirius_response, api_response_code, api_response)
+    return (
+        sirius_response_code,
+        sirius_response,
+        error_details,
+        api_response_code,
+        api_response,
+    )
 
 
-@case_name("Sirius responds with 500")
-def case_500() -> CaseData:
+@case_tags("error")
+@case_name("Sirius responds with a message and details")
+def case_code_missing() -> CaseData:
 
-    sirius_response_code = 500
-    sirius_response = "something has gone terribly wrong"
+    sirius_response_code = None
+    sirius_response = "spurious sirius error message"
+    error_details = "here's some more details"
 
-    # TODO this error message should be in the format {"message": "blah"} to match
-    #  the other custom Sirius errors
     api_response_code = 500
-    api_response = "sirius problem: 500 - something has gone terribly wrong"
+    api_response = "spurious sirius error message, details: here's some more details"
 
-    return (sirius_response_code, sirius_response, api_response_code, api_response)
+    return (
+        sirius_response_code,
+        sirius_response,
+        error_details,
+        api_response_code,
+        api_response,
+    )
 
 
-@case_name("Sirius call does something unexpected")
-def case_500_exception() -> CaseData:
+@case_tags("error")
+@case_name("Sirius responds with a code and details")
+def case_message_missing() -> CaseData:
 
-    sirius_response_code = 200
-    sirius_response = "the data sirius has returned is all wrong"
+    sirius_response_code = 400
+    sirius_response = None
+    error_details = "here's some more details"
 
-    # TODO this error message should be in the format {"message": "blah"} to match
-    #  the other custom Sirius errors
-    api_response_code = 500
-    api_response = "sirius problem: 500 - the data sirius has returned is all wrong"
+    api_response_code = 400
+    api_response = "Unknown error talking to Sirius, details: here's some more details"
 
-    return (sirius_response_code, sirius_response, api_response_code, api_response)
+    return (
+        sirius_response_code,
+        sirius_response,
+        error_details,
+        api_response_code,
+        api_response,
+    )
+
+
+@case_tags("error")
+@case_name("Sirius responds with a code, message")
+def case_missing_details() -> CaseData:
+
+    sirius_response_code = 400
+    sirius_response = "spurious sirius error message"
+    error_details = None
+
+    api_response_code = 400
+    api_response = "spurious sirius error message, details: None"
+
+    return (
+        sirius_response_code,
+        sirius_response,
+        error_details,
+        api_response_code,
+        api_response,
+    )
+
+
+@case_tags("error")
+@case_name("Sirius responds with a code, message, empty details")
+def case_empty_details() -> CaseData:
+
+    sirius_response_code = 400
+    sirius_response = "spurious sirius error message"
+    error_details = ""
+
+    api_response_code = 400
+    api_response = "spurious sirius error message, details: None"
+
+    return (
+        sirius_response_code,
+        sirius_response,
+        error_details,
+        api_response_code,
+        api_response,
+    )

--- a/lambda_functions/v1/tests/flask_app/sirius_service/cases_submit_doc_to_sirius.py
+++ b/lambda_functions/v1/tests/flask_app/sirius_service/cases_submit_doc_to_sirius.py
@@ -1,6 +1,6 @@
 import json
 
-from pytest_cases import case_name, CaseData, cases_generator
+from pytest_cases import case_name, CaseData, cases_generator, case_tags
 
 test_data = {
     "caseRecNumber": "1111",
@@ -15,6 +15,7 @@ test_data = {
 }
 
 
+@case_tags("post_success")
 @case_name("Successful post to Sirius")
 def case_success() -> CaseData:
 
@@ -47,6 +48,27 @@ def case_success() -> CaseData:
     )
 
 
+@case_tags("post_error")
+@case_name("Successful post to Sirius, but Sirius returns an error code")
+def case_error() -> CaseData:
+
+    data = json.dumps(test_data)
+    method = "POST"
+    endpoint = "documents"
+    url_params = None
+
+    expected_responses = {
+        400: [
+            "Payload validation failed in Sirius",
+            "Could not verify URL params in Sirius",
+        ],
+        500: ["Unable to send document to Sirius", "Unknown error talking to Sirius"],
+    }
+
+    return (data, method, endpoint, url_params, expected_responses)
+
+
+@case_tags("post_success")
 @cases_generator(
     "Env var not set {env_var}", env_var=["SIRIUS_BASE_URL", "API_VERSION"]
 )
@@ -58,7 +80,7 @@ def case_missing_env_vars(env_var) -> CaseData:
     url_params = None
 
     expected_status_code = 500
-    expected_response = "something has gone wrong"
+    expected_response = f"Expected environment variables not set, details: '{env_var}'"
 
     return (
         data,


### PR DESCRIPTION
## Purpose

Sirius errors were just being thrown straight out of the docs API and they didn't always make sense.
Main changes are:
- split `new_format_sirius_response` into `format_sirius_success` and `handle_sirius_error` to account for the very different work they do (and split the tests out to match)
- moved the logic to decide if the sirius call is a success or error into `new_submit_document_to_sirius`
- refactored `new_submit_document_to_sirius` a bit to use the new sirius error handler
- renamed the error lookup in `helpers` to something more accurate
- updated tests to match the above, and added a new fixture to mock a bad sirius response


## Approach

Converted Sirius responses into something that makes more sense in the integrator context. Made the adapted error messages more consistent and easier to manage.

## Learning



## Checklist

* [x] I have performed a self-review of my own code
* [x] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation where relevant
* [x] I have added tests to prove my work
* [ ] The product team have tested these changes
* [x] I have run the integration tests (results below)
![image](https://user-images.githubusercontent.com/6086996/86900500-54ccec00-c103-11ea-99a1-19ee64d61f40.png)
