### PR TITLE
Pin pytest-cases at 1.17.0

### DIFF
--- a/lambda_functions/v1/requirements/dev-requirements.txt
+++ b/lambda_functions/v1/requirements/dev-requirements.txt
@@ -7,7 +7,7 @@ yamllint
 pyjwt
 boto3
 moto
-pytest-cases
+pytest-cases==1.17.0
 pytest-ordering
 flask
 flask-lambda


### PR DESCRIPTION
## Purpose

pytest-cases v2+ release has made breaking changes for the current tests

## Approach

Pin the version to the last working version, then allocate time for an upgrade when it can be planned in
