### PR TITLE
Include the sirius response in error messages

### DIFF
--- a/lambda_functions/v1/functions/flask_app/app/api/resources.py
+++ b/lambda_functions/v1/functions/flask_app/app/api/resources.py
@@ -64,7 +64,10 @@ def handle_supporting_docs(caseref, id):
         data=data, caseref=caseref, id=id
     )
 
-    return jsonify(response_data), response_status
+    if response_status in [201, 200]:
+        return jsonify(response_data), response_status
+    else:
+        abort(response_status, description=response_data)
 
 
 @api.route("/clients/<caseref>/reports/<id>/checklists/<checklistId>", methods=["PUT"])
@@ -87,7 +90,10 @@ def handle_checklists(caseref, id, checklistId=None):
         method=request.method,
     )
 
-    return jsonify(response_data), response_status
+    if response_status in [201, 200]:
+        return jsonify(response_data), response_status
+    else:
+        abort(response_status, description=response_data)
 
 
 @api.app_errorhandler(400)

--- a/lambda_functions/v1/functions/flask_app/app/api/sirius_service.py
+++ b/lambda_functions/v1/functions/flask_app/app/api/sirius_service.py
@@ -206,11 +206,6 @@ def format_sirius_success(sirius_response_code, sirius_response=None):
         }
     }
 
-    # if "parentUuid" in sirius_response:
-    #     formatted_response["data"]["attributes"]["parent_id"] = sirius_response[
-    #         "parentUuid"
-    #     ]
-
     return formatted_status_code, formatted_response
 
 

--- a/lambda_functions/v1/functions/flask_app/app/api/sirius_service.py
+++ b/lambda_functions/v1/functions/flask_app/app/api/sirius_service.py
@@ -110,7 +110,7 @@ def new_post_to_sirius(url, data, headers, method):
             error_message="Unable to send document to Sirius", error_details=e
         )
 
-    return r.status_code, json.loads(r.json())
+    return r.status_code, r.json()
 
 
 def new_submit_document_to_sirius(

--- a/lambda_functions/v1/functions/flask_app/app/api/sirius_service.py
+++ b/lambda_functions/v1/functions/flask_app/app/api/sirius_service.py
@@ -199,12 +199,14 @@ def format_sirius_success(sirius_response_code, sirius_response=None):
             "id": sirius_response["uuid"],
             "attributes": {
                 "submission_id": sirius_response["metadata"]["submission_id"],
-                "parent_id": sirius_response["parentUuid"]
-                if "parentUuid" in sirius_response
-                else None,
             },
         }
     }
+
+    if "parentUuid" in sirius_response:
+        formatted_response["data"]["attributes"]["parent_id"] = sirius_response[
+            "parentUuid"
+        ]
 
     return formatted_status_code, formatted_response
 

--- a/lambda_functions/v1/functions/flask_app/app/api/sirius_service.py
+++ b/lambda_functions/v1/functions/flask_app/app/api/sirius_service.py
@@ -199,14 +199,17 @@ def format_sirius_success(sirius_response_code, sirius_response=None):
             "id": sirius_response["uuid"],
             "attributes": {
                 "submission_id": sirius_response["metadata"]["submission_id"],
+                "parent_id": sirius_response["parentUuid"]
+                if "parentUuid" in sirius_response
+                else None,
             },
         }
     }
 
-    if "parentUuid" in sirius_response:
-        formatted_response["data"]["attributes"]["parent_id"] = sirius_response[
-            "parentUuid"
-        ]
+    # if "parentUuid" in sirius_response:
+    #     formatted_response["data"]["attributes"]["parent_id"] = sirius_response[
+    #         "parentUuid"
+    #     ]
 
     return formatted_status_code, formatted_response
 

--- a/lambda_functions/v1/functions/flask_app/app/api/sirius_service.py
+++ b/lambda_functions/v1/functions/flask_app/app/api/sirius_service.py
@@ -110,7 +110,7 @@ def new_post_to_sirius(url, data, headers, method):
             error_message="Unable to send document to Sirius", error_details=e
         )
 
-    return r.status_code, r.json()
+    return r.status_code, json.loads(r.json())
 
 
 def new_submit_document_to_sirius(

--- a/lambda_functions/v1/functions/flask_app/app/api/sirius_service.py
+++ b/lambda_functions/v1/functions/flask_app/app/api/sirius_service.py
@@ -161,11 +161,15 @@ def new_submit_document_to_sirius(
             )
         elif sirius_status_code == 404:
             return handle_sirius_error(
-                error_code=400, error_message="Could not verify URL params in Sirius"
+                error_code=400,
+                error_message="Could not verify URL params in " "Sirius",
+                error_details=sirius_response,
             )
         elif sirius_status_code == 400:
             return handle_sirius_error(
-                error_code=400, error_message="Payload validation failed in Sirius"
+                error_code=400,
+                error_message="Validation failed in Sirius",
+                error_details=sirius_response,
             )
         else:
             return handle_sirius_error(
@@ -183,7 +187,12 @@ def handle_sirius_error(error_code=None, error_message=None, error_details=None)
     error_message = (
         error_message if error_message else "Unknown error talking to " "Sirius"
     )
-    error_details = str(error_details) if len(str(error_details)) > 0 else "None"
+
+    try:
+        sirius_error_details = error_details["detail"]
+        error_details = sirius_error_details
+    except (KeyError, TypeError):
+        error_details = str(error_details) if len(str(error_details)) > 0 else "None"
 
     message = f"{error_message}, details: {str(error_details)}"
     logger.error(message)

--- a/lambda_functions/v1/integration_tests/conftest.py
+++ b/lambda_functions/v1/integration_tests/conftest.py
@@ -24,7 +24,7 @@ aws_dev_config = {
 
 aws_flask_config = {
     "name": "AWS Flask",
-    "url": "https://in263siriuserr.dev.deputy-reporting.api.opg.service.justice.gov"
+    "url": "https://in265.dev.deputy-reporting.api.opg.service.justice.gov"
     ".uk/v1/flask",
     "security": "aws_signature",
     "case_ref": "03707908",

--- a/lambda_functions/v1/tests/flask_app/conftest.py
+++ b/lambda_functions/v1/tests/flask_app/conftest.py
@@ -321,6 +321,7 @@ def patched_post(monkeypatch, request):
             return payload
 
         mock_response.json = json_func
+        print(f"mock_response.json: {mock_response.json}")
 
         return mock_response.status_code, mock_response.json()
 

--- a/lambda_functions/v1/tests/flask_app/conftest.py
+++ b/lambda_functions/v1/tests/flask_app/conftest.py
@@ -321,7 +321,6 @@ def patched_post(monkeypatch, request):
             return payload
 
         mock_response.json = json_func
-        print(f"mock_response.json: {mock_response.json}")
 
         return mock_response.status_code, mock_response.json()
 

--- a/lambda_functions/v1/tests/flask_app/conftest.py
+++ b/lambda_functions/v1/tests/flask_app/conftest.py
@@ -350,7 +350,7 @@ def patched_post_broken_sirius(request, monkeypatch):
                     "type": "http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html",
                     "title": "Bad Request",
                     "status": "400",
-                    "detail": f"Payload failed validation, details of what failed here",
+                    "detail": "Payload failed validation, details of what failed here",
                     "instance": "string",
                 }
 

--- a/lambda_functions/v1/tests/flask_app/conftest.py
+++ b/lambda_functions/v1/tests/flask_app/conftest.py
@@ -327,7 +327,8 @@ def patched_post(monkeypatch, request):
     monkeypatch.setattr(api.sirius_service, "new_post_to_sirius", mock_post_to_sirius)
 
 
-@pytest.fixture(autouse=False, params=[400, 404, 500])
+# @pytest.fixture(autouse=False, params=[400, 404, 500])
+@pytest.fixture(autouse=False)
 def patched_post_broken_sirius(request, monkeypatch):
     def mock_post_to_broken_sirius(*args, **kwargs):
         print("MOCK POST TO BROKEN SIRIUS")
@@ -338,8 +339,8 @@ def patched_post_broken_sirius(request, monkeypatch):
         mock_response = requests.Response()
         mock_response.status_code = request.param
 
-        if case_ref in valid_case_refs:
-            mock_response.status_code = request.param
+        # if case_ref in valid_case_refs:
+        mock_response.status_code = request.param
 
         if mock_response.status_code == 400 and case_ref in valid_case_refs:
 
@@ -349,8 +350,7 @@ def patched_post_broken_sirius(request, monkeypatch):
                     "type": "http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html",
                     "title": "Bad Request",
                     "status": "400",
-                    "detail": f"Payload failed validation, details of what failed "
-                    f"here {case_ref}",
+                    "detail": f"Payload failed validation, details of what failed here",
                     "instance": "string",
                 }
 
@@ -380,14 +380,16 @@ def patched_post_broken_sirius(request, monkeypatch):
                 }
 
         else:
-            return {
-                "validation_errors": {},
-                "type": "http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html",
-                "title": "Not Found",
-                "status": mock_response.status_code,
-                "detail": "This is a generic Sirius error",
-                "instance": "string",
-            }
+
+            def json_func():
+                return {
+                    "validation_errors": {},
+                    "type": "http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html",
+                    "title": "Not Found",
+                    "status": mock_response.status_code,
+                    "detail": "This is a generic Sirius error",
+                    "instance": "string",
+                }
 
         mock_response.json = json_func
         print(f"mock_response.json: {mock_response.json}")

--- a/lambda_functions/v1/tests/flask_app/routes/cases_custom_endpoint_errors.py
+++ b/lambda_functions/v1/tests/flask_app/routes/cases_custom_endpoint_errors.py
@@ -1,3 +1,5 @@
+import json
+
 from pytest_cases import CaseData, case_tags, cases_generator
 
 """
@@ -7,22 +9,85 @@ from pytest_cases import CaseData, case_tags, cases_generator
 """
 
 test_urls = [
-    {"name": "reports", "method": "POST", "url": "1111/reports"},
+    {
+        "name": "reports",
+        "method": "POST",
+        "url": "1111/reports",
+        "test_data": {
+            "report": {
+                "data": {
+                    "type": "reports",
+                    "attributes": {
+                        "submission_id": 12345,
+                        "reporting_period_from": "2019-01-01",
+                        "reporting_period_to": "2019-12-31",
+                        "year": 2019,
+                        "date_submitted": "2020-01-03T09:30:00.001Z",
+                        "type": "PF",
+                    },
+                    "file": {
+                        "name": "Report_1234567T_2018_2019_11111.pdf",
+                        "mimetype": "application/pdf",
+                        "source": "string",
+                    },
+                }
+            }
+        },
+    },
     {
         "name": "supportingdocuments",
         "method": "POST",
         "url": "1111/reports/de26f80c-ed6d-4c52-b6bd-e0260bb0faf0/supportingdocuments",
+        "test_data": {
+            "supporting_document": {
+                "data": {
+                    "type": "supportingdocuments",
+                    "attributes": {"submission_id": 12345},
+                    "file": {
+                        "name": "Report_1234567T_2018_2019_11111.pdf",
+                        "mimetype": "application/pdf",
+                        "source": "string",
+                    },
+                }
+            }
+        },
     },
     {
         "name": "checklists",
         "method": "POST",
         "url": "1111/reports/de26f80c-ed6d-4c52-b6bd-e0260bb0faf0/checklists",
+        "test_data": {
+            "checklist": {
+                "data": {
+                    "type": "supportingdocuments",
+                    "attributes": {"submission_id": 12345},
+                    "file": {
+                        "name": "Report_1234567T_2018_2019_11111.pdf",
+                        "mimetype": "application/pdf",
+                        "source": "string",
+                    },
+                }
+            }
+        },
     },
     {
         "name": "checklists update",
         "method": "PUT",
         "url": "1111/reports/de26f80c-ed6d-4c52-b6bd-e0260bb0faf0/checklists/ea35592e-"
         "a1a7-4f87-98e9-1519bcb086ac",
+        "test_data": {
+            "checklist": {
+                "data": {
+                    "type": "supportingdocuments",
+                    "attributes": {"submission_id": 12345},
+                    "file": {
+                        "name": "Report_1234567T_2018_2019_11111.pdf",
+                        "mimetype": "application/pdf",
+                        "source": "string",
+                    },
+                }
+            }
+        },
     },
 ]
 
@@ -79,6 +144,32 @@ def case_400_not_json(test_url) -> CaseData:
 
     test_headers = {"Content-Type": "application/json"}
     test_data = {"i am not": "json"}
+    test_method = test_url["method"]
+
+    expected_response_status_code = 400
+    expected_response_data = "OPGDATA-API-INVALIDREQUEST"
+
+    return (
+        test_url,
+        test_headers,
+        test_data,
+        test_method,
+        expected_response_status_code,
+        expected_response_data,
+    )
+
+
+@case_tags("endpoint")
+@cases_generator("Test custom 400 bad url params for {test_url}", test_url=test_urls)
+def case_400_bad_url_params(test_url) -> CaseData:
+
+    print(f"test_url: {test_url}")
+
+    test_headers = {"Content-Type": "application/json"}
+
+    test_url["url"] = test_url["url"].replace("1111", "not-a-real-caseref")
+
+    test_data = json.dumps(test_url["test_data"])
     test_method = test_url["method"]
 
     expected_response_status_code = 400

--- a/lambda_functions/v1/tests/flask_app/routes/cases_custom_endpoint_errors.py
+++ b/lambda_functions/v1/tests/flask_app/routes/cases_custom_endpoint_errors.py
@@ -159,7 +159,8 @@ def case_400_not_json(test_url) -> CaseData:
     )
 
 
-@case_tags("endpoint")
+# TODO add separate test for these - it can't handle the error code parameters
+@case_tags("endpoint, custom_message")
 @cases_generator("Test custom 400 bad url params for {test_url}", test_url=test_urls)
 def case_400_bad_url_params(test_url) -> CaseData:
 

--- a/lambda_functions/v1/tests/flask_app/routes/test_custom_errors.py
+++ b/lambda_functions/v1/tests/flask_app/routes/test_custom_errors.py
@@ -9,6 +9,11 @@ from lambda_functions.v1.tests.flask_app.routes import cases_custom_endpoint_err
 @pytest.mark.usefixtures(
     "patched_get_secret", "patched_post_broken_sirius", "patched_send_get_to_sirius",
 )
+@pytest.mark.parametrize(
+    "patched_post_broken_sirius",
+    [400, 404, 500],
+    indirect=["patched_post_broken_sirius"],
+)
 @cases_data(module=cases_custom_endpoint_errors, has_tag="endpoint")
 def test_custom_errors(server, case_data: CaseDataGetter):
     (

--- a/lambda_functions/v1/tests/flask_app/routes/test_custom_errors.py
+++ b/lambda_functions/v1/tests/flask_app/routes/test_custom_errors.py
@@ -7,9 +7,7 @@ from lambda_functions.v1.tests.flask_app.routes import cases_custom_endpoint_err
 
 @pytest.mark.run(order=1)
 @pytest.mark.usefixtures(
-    "patched_get_secret",
-    "patched_submit_document_to_sirius",
-    "patched_send_get_to_sirius",
+    "patched_get_secret", "patched_post_broken_sirius", "patched_send_get_to_sirius",
 )
 @cases_data(module=cases_custom_endpoint_errors, has_tag="endpoint")
 def test_custom_errors(server, case_data: CaseDataGetter):

--- a/lambda_functions/v1/tests/flask_app/sirius_service/cases_format_sirius_response.py
+++ b/lambda_functions/v1/tests/flask_app/sirius_service/cases_format_sirius_response.py
@@ -48,7 +48,7 @@ def case_200_no_parents() -> CaseData:
         "data": {
             "type": "Report - General",
             "id": "5a8b1a26-8296-4373-ae61-f8d0b250e773",
-            "attributes": {"submission_id": 123, "parent_id": None},
+            "attributes": {"submission_id": 123},
         }
     }
 

--- a/lambda_functions/v1/tests/flask_app/sirius_service/cases_format_sirius_response.py
+++ b/lambda_functions/v1/tests/flask_app/sirius_service/cases_format_sirius_response.py
@@ -48,7 +48,7 @@ def case_200_no_parents() -> CaseData:
         "data": {
             "type": "Report - General",
             "id": "5a8b1a26-8296-4373-ae61-f8d0b250e773",
-            "attributes": {"submission_id": 123},
+            "attributes": {"submission_id": 123, "parent_id": None},
         }
     }
 


### PR DESCRIPTION
## Purpose

Mapped the actual sirius error into our custom API error where possible

## Approach



## Learning



## Checklist

* [x] I have performed a self-review of my own code
* [x] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation where relevant
* [x] I have added tests to prove my work
* [ ] The product team have tested these changes
* [x] I have run the integration tests (results below)


![image](https://user-images.githubusercontent.com/6086996/87300535-ea062100-c505-11ea-83f2-1e9a02c9a2b9.png)


As if it needed to prove itself, first time I ran the integration tests I had a bad caseref:, check out that helpful error message!

![image](https://user-images.githubusercontent.com/6086996/87300590-fee2b480-c505-11ea-90f4-8542a852a608.png)

