### PR TITLE
IN-280 Remove validation around checklists submission_ids

### DIFF
--- a/deputy-reporting-openapi-v1.yml
+++ b/deputy-reporting-openapi-v1.yml
@@ -415,7 +415,7 @@ paths:
                     - data
                   properties:
                     data:
-                      $ref: '#/components/schemas/ReportSupportingDocument'
+                      $ref: '#/components/schemas/ReportChecklist'
       responses:
         201:
           description: Document created
@@ -531,7 +531,7 @@ paths:
                     - data
                   properties:
                     data:
-                      $ref: '#/components/schemas/ReportSupportingDocument'
+                      $ref: '#/components/schemas/ReportChecklist'
       responses:
         200:
           description: Document updated
@@ -924,7 +924,7 @@ paths:
                     - data
                   properties:
                     data:
-                      $ref: '#/components/schemas/ReportSupportingDocument'
+                      $ref: '#/components/schemas/ReportChecklist'
       responses:
         201:
           description: Document created
@@ -1040,7 +1040,7 @@ paths:
                     - data
                   properties:
                     data:
-                      $ref: '#/components/schemas/ReportSupportingDocument'
+                      $ref: '#/components/schemas/ReportChecklist'
       responses:
         200:
           description: Document updated
@@ -1163,6 +1163,26 @@ components:
               example: "PF"
         file:
           $ref: '#/components/schemas/file'
+    ReportChecklist:
+      type: object
+      required:
+        - type
+        - attributes
+        - file
+      properties:
+        type:
+          type: string
+          pattern: '^checklists$'
+          example: checklists
+        id:
+          $ref: '#/components/schemas/DocumentUuid'
+        attributes:
+          type: object
+          properties:
+            submission_id:
+              $ref: '#/components/schemas/submissionId'
+        file:
+          $ref: '#/components/schemas/file'
     ReportSupportingDocument:
       type: object
       required:
@@ -1172,7 +1192,7 @@ components:
       properties:
         type:
           type: string
-          pattern: '^supportingdocuments|checklists$'
+          pattern: '^supportingdocuments'
           example: supportingdocuments
         id:
           $ref: '#/components/schemas/DocumentUuid'

--- a/lambda_functions/v1/functions/checklists/app/checklists.py
+++ b/lambda_functions/v1/functions/checklists/app/checklists.py
@@ -82,7 +82,7 @@ def validate_event(event):
     required_body_structure = {
         "checklist": {
             "data": {
-                "attributes": {"submission_id": 0},
+                "attributes": {},
                 "file": {"name": "string", "mimetype": "string", "source": "string"},
             }
         }

--- a/lambda_functions/v1/functions/checklists/app/sirius_service.py
+++ b/lambda_functions/v1/functions/checklists/app/sirius_service.py
@@ -142,7 +142,9 @@ def format_sirius_response(sirius_response=None, sirius_response_code=500):
                     "type": sirius_response["type"],
                     "id": sirius_response["uuid"],
                     "attributes": {
-                        "submission_id": sirius_response["metadata"]["submission_id"],
+                        "submission_id": sirius_response["metadata"]["submission_id"]
+                        if "submission_id" in sirius_response["metadata"]
+                        else None,
                         "parent_id": sirius_response["parentUuid"]
                         if "parentUuid" in sirius_response
                         else None,

--- a/lambda_functions/v1/functions/checklists/app/sirius_service.py
+++ b/lambda_functions/v1/functions/checklists/app/sirius_service.py
@@ -141,14 +141,7 @@ def format_sirius_response(sirius_response=None, sirius_response_code=500):
                 "data": {
                     "type": sirius_response["type"],
                     "id": sirius_response["uuid"],
-                    "attributes": {
-                        "submission_id": sirius_response["metadata"]["submission_id"]
-                        if "submission_id" in sirius_response["metadata"]
-                        else None,
-                        "parent_id": sirius_response["parentUuid"]
-                        if "parentUuid" in sirius_response
-                        else None,
-                    },
+                    "attributes": sirius_response["metadata"]
                 }
             }
         else:

--- a/lambda_functions/v1/functions/flask_app/app/api/sirius_service.py
+++ b/lambda_functions/v1/functions/flask_app/app/api/sirius_service.py
@@ -207,7 +207,9 @@ def format_sirius_success(sirius_response_code, sirius_response=None):
             "type": sirius_response["type"],
             "id": sirius_response["uuid"],
             "attributes": {
-                "submission_id": sirius_response["metadata"]["submission_id"],
+                "submission_id": sirius_response["metadata"]["submission_id"]
+                if "submission_id" in sirius_response["metadata"]
+                else None,
                 "parent_id": sirius_response["parentUuid"]
                 if "parentUuid" in sirius_response
                 else None,

--- a/lambda_functions/v1/functions/flask_app/app/api/sirius_service.py
+++ b/lambda_functions/v1/functions/flask_app/app/api/sirius_service.py
@@ -269,7 +269,9 @@ def format_sirius_response(sirius_response=None, sirius_response_code=500):
                     "type": sirius_response["type"],
                     "id": sirius_response["uuid"],
                     "attributes": {
-                        "submission_id": sirius_response["metadata"]["submission_id"],
+                        "submission_id": sirius_response["metadata"]["submission_id"]
+                        if "submission_id" in sirius_response["metadata"]
+                        else None,
                         "parent_id": sirius_response["parentUuid"]
                         if "parentUuid" in sirius_response
                         else None,

--- a/lambda_functions/v1/tests/checklists/checklists_endpoint_test_cases.py
+++ b/lambda_functions/v1/tests/checklists/checklists_endpoint_test_cases.py
@@ -1,0 +1,206 @@
+import copy
+
+from pytest_cases import CaseData
+
+default_body = {
+    "checklist": {
+        "data": {
+            "type": "checklists",
+            "attributes": {"submission_id": 231231, "report_id": "not a real id"},
+            "file": {
+                "name": "Checklist.pdf",
+                "mimetype": "application/pdf",
+                "source": "string",
+            },
+        }
+    }
+}
+
+default_case_ref = "12345678"
+
+default_report_id = "443e881b-370a-4343-acb3-9965d341662f"
+
+nondigital_report_id = "99999999-9999-9999-9999-999999999999"
+
+
+def case_happy_path() -> CaseData:
+    """
+    Data for checklists endpoint tests
+
+    Returns:
+        All data present, Sirius payload is populated as expected
+    """
+
+    body = copy.deepcopy(default_body)
+    case_ref = default_case_ref
+    report_id = default_report_id
+    expected_result = (True, [])
+
+    return body, case_ref, report_id, expected_result
+
+
+def case_missing_required_field() -> CaseData:
+    """
+    Data for reports endpoint tests
+
+    Returns:
+        Missing required field - filename
+    """
+
+    body = copy.deepcopy(default_body)
+    case_ref = default_case_ref
+    report_id = default_report_id
+    expected_result = (False, ["checklist->data->attributes->file->name"])
+
+    body["checklist"]["data"]["file"].pop("name")
+
+    return body, case_ref, report_id, expected_result
+
+
+def case_null_required_field() -> CaseData:
+    """
+    Data for reports endpoint tests
+
+    Returns:
+        Null required field - filename
+    """
+
+    body = copy.deepcopy(default_body)
+    case_ref = default_case_ref
+    report_id = default_report_id
+    expected_result = (False, ["checklist->data->attributes->file->name"])
+
+    body["checklist"]["data"]["file"]["name"] = None
+    return body, case_ref, report_id, expected_result
+
+
+def case_empty_required_field() -> CaseData:
+    """
+    Data for reports endpoint tests
+
+    Returns:
+        Empty required field - filename
+    """
+
+    body = copy.deepcopy(default_body)
+    case_ref = default_case_ref
+    report_id = default_report_id
+    expected_result = (False, ["checklist->data->attributes->file->name"])
+
+    body["checklist"]["data"]["file"]["name"] = ""
+
+    return body, case_ref, report_id, expected_result
+
+
+def case_missing_multiple_required_fields() -> CaseData:
+    """
+    Data for reports endpoint tests
+
+    Returns:
+        Missing multiple required fields - file_mimetype and file_name
+    """
+
+    body = copy.deepcopy(default_body)
+    case_ref = default_case_ref
+    report_id = default_report_id
+    expected_result = (
+        False,
+        [
+            "checklist->data->attributes->file->mimetype",
+            "checklist->data->attributes->file->name",
+        ],
+    )
+
+    body["checklist"]["data"]["file"].pop("mimetype")
+    body["checklist"]["data"]["file"].pop("name")
+
+    return body, case_ref, report_id, expected_result
+
+
+def case_bad_multiple_required_fields() -> CaseData:
+    """
+    Data for reports endpoint tests
+
+    Returns:
+        null file_name
+        missing file_type
+    """
+
+    body = copy.deepcopy(default_body)
+    case_ref = default_case_ref
+    report_id = default_report_id
+    expected_result = (
+        False,
+        [
+            "checklist->data->attributes->file->name",
+            "checklist->data->attributes->file->mimetype",
+        ],
+    )
+
+    body["checklist"]["data"]["file"]["name"] = None
+    body["checklist"]["data"]["file"].pop("mimetype")
+
+    return body, case_ref, report_id, expected_result
+
+
+def case_submission_id_is_missing() -> CaseData:
+    """
+    Data for reports endpoint tests
+
+    Returns:
+        missing submission_id
+    """
+
+    body = copy.deepcopy(default_body)
+    case_ref = default_case_ref
+    report_id = default_report_id
+    expected_result = (
+        True,
+        [],
+    )
+
+    body["checklist"]["data"]["attributes"].pop("submission_id")
+
+    return body, case_ref, report_id, expected_result
+
+
+def case_submission_id_is_null() -> CaseData:
+    """
+    Data for reports endpoint tests
+
+    Returns:
+        null submission_id
+    """
+
+    body = copy.deepcopy(default_body)
+    case_ref = default_case_ref
+    report_id = default_report_id
+    expected_result = (
+        True,
+        [],
+    )
+
+    body["checklist"]["data"]["attributes"]["submission_id"] = None
+
+    return body, case_ref, report_id, expected_result
+
+
+def case_submission_id_is_empty() -> CaseData:
+    """
+    Data for reports endpoint tests
+
+    Returns:
+        empty string submission_id
+    """
+
+    body = copy.deepcopy(default_body)
+    case_ref = default_case_ref
+    report_id = default_report_id
+    expected_result = (
+        True,
+        [],
+    )
+
+    body["checklist"]["data"]["attributes"]["submission_id"] = ""
+
+    return body, case_ref, report_id, expected_result

--- a/lambda_functions/v1/tests/checklists/conftest.py
+++ b/lambda_functions/v1/tests/checklists/conftest.py
@@ -1,0 +1,183 @@
+import json
+
+import pytest
+import requests
+
+from lambda_functions.v1.functions.checklists.app import sirius_service, checklists
+
+test_data = {
+    "valid_clients": ["valid_client_id", "0319392T", "12345678", "22814959"],
+    "invalid_clients": ["invalid_client_id"],
+}
+
+
+@pytest.fixture(autouse=True)
+def default_sirius_checklists_request(
+    default_request_case_ref, default_request_report_id
+):
+    return {
+        "type": "Report - Checklist",
+        "caseRecNumber": default_request_case_ref,
+        "metadata": {"submission_id": 231231, "report_id": default_request_report_id, "is_checklist": "true"},
+        "file": {
+            "name": "checklist.pdf",
+            "source": "string",
+            "type": "application/pdf",
+        },
+    }
+
+
+@pytest.fixture(autouse=True)
+def sirius_checklists_request_with_no_report_submission(
+    default_request_case_ref,
+    nondigital_request_report_id
+):
+    return {
+        "type": "Report - Checklist",
+        "caseRecNumber": default_request_case_ref,
+        "metadata": {"report_id": nondigital_request_report_id, "is_checklist": "true"},
+        "file": {
+            "name": "checklist.pdf",
+            "source": "string",
+            "type": "application/pdf",
+        },
+    }
+
+
+@pytest.fixture(autouse=True)
+def default_checklists_request_body(default_request_report_id):
+    return {
+        "checklist": {
+            "data": {
+                "type": "checklists",
+                "id": default_request_report_id,
+                "attributes": {"submission_id": 231231},
+                "file": {
+                    "name": "checklist.pdf",
+                    "mimetype": "application/pdf",
+                    "source": "string",
+                },
+            }
+        }
+    }
+
+
+@pytest.fixture(autouse=True)
+def checklists_request_body_with_no_report_submission(nondigital_request_report_id):
+    return {
+        "checklist": {
+            "data": {
+                "type": "checklists",
+                "id": nondigital_request_report_id,
+                "attributes": {},
+                "file": {
+                    "name": "checklist.pdf",
+                    "mimetype": "application/pdf",
+                    "source": "string",
+                },
+            }
+        }
+    }
+
+
+@pytest.fixture(autouse=True)
+def default_request_case_ref():
+    return "12345678"
+
+
+@pytest.fixture(autouse=True)
+def default_request_report_id():
+    return "df6ff8dd-01a3-4f02-833b-01655f9b4c9e"
+
+
+@pytest.fixture(autouse=True)
+def nondigital_request_report_id():
+    return "99999999-9999-9999-9999-999999999999"
+
+
+@pytest.fixture(autouse=True)
+def mock_env_setup(monkeypatch):
+    monkeypatch.setenv("BASE_URL", "http://localhost:8080")
+    monkeypatch.setenv("SIRIUS_BASE_URL", "http://sirius_url.com")
+    monkeypatch.setenv("SIRIUS_PUBLIC_API_URL", "api/public/v1/")
+    monkeypatch.setenv("LOGGER_LEVEL", "DEBUG")
+    monkeypatch.setenv("JWT_SECRET", "THIS_IS_MY_SECRET_KEY")
+    monkeypatch.setenv("ENVIRONMENT", "development")
+    monkeypatch.setenv("SESSION_DATA", "publicapi@opgtest.com")
+    monkeypatch.setenv("API_VERSION", "v1")
+
+
+sirius_checklists_response = json.dumps(
+    {
+        "type": "Report - Checklist",
+        "filename": "b11a291e6dae6_checklist.pdf",
+        "mimeType": "application/pdf",
+        "metadata": {"submission_id": 12345},
+        "uuid": "16aae069-99b9-494f-948b-4c2057ec5551"
+    }
+)
+
+
+@pytest.fixture
+def patched_requests(monkeypatch):
+    def mock_post(*args, **kwargs):
+        print("MOCK POST")
+        data = kwargs["data"]
+
+        mock_response = requests.Response()
+
+        try:
+            if json.loads(data)["caseRecNumber"] in test_data["valid_clients"]:
+                mock_response.status_code = 201
+                mock_response._content = sirius_checklists_response.encode("UTF-8")
+            elif json.loads(data)["caseRecNumber"] is None:
+                mock_response.status_code = 500
+                mock_response.json = None
+            else:
+                mock_response.status_code = 400
+                mock_response.json = None
+        except KeyError:
+            mock_response.status_code = 500
+            mock_response.json = None
+
+        return mock_response
+
+    def mock_get(*args, **kwargs):
+        url = kwargs["url"]
+        mock_response = requests.Response()
+
+        if url == "https://frontend-feature5.dev.sirius.opg.digital/":
+            mock_response.status_code = 200
+            mock_response._content = json.dumps([{"data": "success"}]).encode("UTF-8")
+        else:
+            mock_response.status_code = 500
+            mock_response._content = None
+
+        return mock_response
+
+    monkeypatch.setattr(requests, "post", mock_post)
+    monkeypatch.setattr(requests, "get", mock_get)
+
+
+@pytest.fixture
+def patched_get_secret(monkeypatch):
+    def mock_secret(*args, **kwargs):
+        return "this_is_a_secret_string"
+
+    monkeypatch.setattr(sirius_service, "get_secret", mock_secret)
+
+
+@pytest.fixture
+def patched_validate_event_fail(monkeypatch):
+    def mock_invalid(*args, **kwargs):
+        return False, ["file_name", "file_type"]
+
+    monkeypatch.setattr(checklists, "validate_event", mock_invalid)
+
+
+@pytest.fixture
+def patched_validate_event_success(monkeypatch):
+    def mock_valid(*args, **kwargs):
+        return True, []
+
+    monkeypatch.setattr(checklists, "validate_event", mock_valid)

--- a/lambda_functions/v1/tests/checklists/test_checklists_endpoint.py
+++ b/lambda_functions/v1/tests/checklists/test_checklists_endpoint.py
@@ -1,0 +1,114 @@
+import json
+
+from pytest_cases import (
+    cases_data,
+    CaseDataGetter,
+)
+
+from lambda_functions.v1.functions.checklists.app.checklists import (
+    lambda_handler,
+    transform_event_to_sirius_payload,
+    validate_event,
+)
+from lambda_functions.v1.tests.helpers.use_test_data import (
+    is_valid_schema,
+    load_data,
+    build_aws_event,
+)
+from lambda_functions.v1.tests.checklists import (
+    checklists_endpoint_test_cases,
+)
+
+
+def test_lambda_handler(
+    patched_requests, patched_get_secret, patched_validate_event_success
+):
+    event = load_data("checklists_event.json", as_json=False)
+    context = None
+
+    result = lambda_handler(event=event, context=context)
+    assert result["statusCode"] == 201
+    assert is_valid_schema(result, "standard_lambda_response_schema.json")
+    assert is_valid_schema(json.loads(result["body"]), "201_created_schema.json")
+
+
+def test_lambda_handler_fail(
+    patched_requests, patched_get_secret, patched_validate_event_fail
+):
+    event = load_data("checklists_event.json", as_json=False)
+    context = None
+
+    result = lambda_handler(event=event, context=context)
+    assert result["statusCode"] == 400
+    assert is_valid_schema(result, "standard_lambda_response_schema.json")
+
+
+@cases_data(module=checklists_endpoint_test_cases)
+def test_validate_event(case_data: CaseDataGetter):
+    body, case_ref, report_id, expected_result = case_data.get()
+    path_params = {"caseref": case_ref, "id": report_id}
+    event = build_aws_event(
+        event_body=json.dumps(body), event_path_parementers=path_params, as_json=False
+    )
+
+    valid_event, errors = validate_event(event)
+
+    assert valid_event == expected_result[0]
+    assert sorted(errors) == sorted(expected_result[1])
+
+
+def test_transform_event_to_sirius_request(
+    default_checklists_request_body,
+    default_request_case_ref,
+    default_request_report_id,
+    default_sirius_checklists_request
+):
+    path_params = {"caseref": default_request_case_ref, "id": default_request_report_id}
+    event = build_aws_event(
+        event_body=json.dumps(default_checklists_request_body),
+        event_path_parementers=path_params,
+        as_json=False,
+    )
+
+    payload = transform_event_to_sirius_payload(event)
+
+    assert is_valid_schema(json.loads(payload), "sirius_documents_payload_schema.json")
+    assert payload == json.dumps(default_sirius_checklists_request)
+
+
+def test_transform_event_to_sirius_request_with_no_report_submission(
+    default_request_case_ref,
+    nondigital_request_report_id,
+    checklists_request_body_with_no_report_submission,
+    sirius_checklists_request_with_no_report_submission
+):
+    path_params = {"caseref": default_request_case_ref, "id": nondigital_request_report_id}
+    event = build_aws_event(
+        event_body=json.dumps(checklists_request_body_with_no_report_submission),
+        event_path_parementers=path_params,
+        as_json=False,
+    )
+
+    payload = transform_event_to_sirius_payload(event)
+
+    assert is_valid_schema(json.loads(payload), "sirius_documents_payload_schema.json")
+    assert payload == json.dumps(sirius_checklists_request_with_no_report_submission)
+
+
+def test_sirius_request_has_report_id_from_path(
+    default_checklists_request_body,
+    default_request_case_ref,
+    default_request_report_id,
+    default_sirius_checklists_request,
+):
+    default_checklists_request_body["checklist"]["data"]["attributes"]["report_id"] = "uuid_from_attributes"
+    path_params = {"caseref": default_request_case_ref, "id": "uuid_from_path"}
+    event = build_aws_event(
+        event_body=json.dumps(default_checklists_request_body),
+        event_path_parementers=path_params,
+        as_json=False,
+    )
+
+    payload = transform_event_to_sirius_payload(event)
+
+    assert json.loads(payload)["metadata"]["report_id"] == "uuid_from_path"

--- a/lambda_functions/v1/tests/checklists/test_checklists_sirius_service.py
+++ b/lambda_functions/v1/tests/checklists/test_checklists_sirius_service.py
@@ -14,46 +14,6 @@ from lambda_functions.v1.functions.checklists.app.sirius_service import (
     send_get_to_sirius,
 )
 
-
-# import boto3
-# from aws_xray_sdk.core import xray_recorder
-# from botocore.exceptions import ClientError
-# from moto import mock_secretsmanager
-
-
-# TODO this does not work through CI, something to do with aws xray,
-#  see https://github.com/aws/aws-xray-sdk-python/issues/155
-# @pytest.mark.parametrize(
-#     "secret_code, environment, region",
-#     [("i_am_a_secret_code", "development", "eu-west-1")],
-# )
-# @mock_secretsmanager
-# def test_get_secret(secret_code, environment, region):
-#     # Disable sampling for tests, see github issue:
-#     # https://github.com/aws/aws-xray-sdk-python/issues/155
-#     xray_recorder.configure(sampling=False)
-#
-#     session = boto3.session.Session()
-#     client = session.client(service_name="secretsmanager", region_name=region)
-#
-#     client.create_secret(Name=f"{environment}/jwt-key", SecretString=secret_code)
-#     assert get_secret(environment) == secret_code
-#
-#     with pytest.raises(ClientError):
-#         get_secret("not_a_real_environment")
-
-
-# TODO this does not work through CI, something to do with aws xray,
-#  see https://github.com/aws/aws-xray-sdk-python/issues/155
-# def test_sirius_does_not_exist(monkeypatch, default_sirius_supporting_docs_request):
-#     headers = {"Content-Type": "application/json"}
-#     body = default_sirius_supporting_docs_request
-#
-#     response = submit_document_to_sirius(
-#         url="http://this_url_does_not_exist/", data=body, headers=headers
-#     )
-#
-#     assert response["statusCode"] == 404
 from lambda_functions.v1.tests.helpers.use_test_data import is_valid_schema
 
 

--- a/lambda_functions/v1/tests/checklists/test_checklists_sirius_service.py
+++ b/lambda_functions/v1/tests/checklists/test_checklists_sirius_service.py
@@ -1,0 +1,312 @@
+import json
+import urllib.parse
+
+import jwt
+import pytest
+from jwt import DecodeError
+
+from lambda_functions.v1.functions.checklists.app.sirius_service import (
+    submit_document_to_sirius,
+    build_sirius_url,
+    build_sirius_headers,
+    # get_secret,
+    format_sirius_response,
+    send_get_to_sirius,
+)
+
+
+# import boto3
+# from aws_xray_sdk.core import xray_recorder
+# from botocore.exceptions import ClientError
+# from moto import mock_secretsmanager
+
+
+# TODO this does not work through CI, something to do with aws xray,
+#  see https://github.com/aws/aws-xray-sdk-python/issues/155
+# @pytest.mark.parametrize(
+#     "secret_code, environment, region",
+#     [("i_am_a_secret_code", "development", "eu-west-1")],
+# )
+# @mock_secretsmanager
+# def test_get_secret(secret_code, environment, region):
+#     # Disable sampling for tests, see github issue:
+#     # https://github.com/aws/aws-xray-sdk-python/issues/155
+#     xray_recorder.configure(sampling=False)
+#
+#     session = boto3.session.Session()
+#     client = session.client(service_name="secretsmanager", region_name=region)
+#
+#     client.create_secret(Name=f"{environment}/jwt-key", SecretString=secret_code)
+#     assert get_secret(environment) == secret_code
+#
+#     with pytest.raises(ClientError):
+#         get_secret("not_a_real_environment")
+
+
+# TODO this does not work through CI, something to do with aws xray,
+#  see https://github.com/aws/aws-xray-sdk-python/issues/155
+# def test_sirius_does_not_exist(monkeypatch, default_sirius_supporting_docs_request):
+#     headers = {"Content-Type": "application/json"}
+#     body = default_sirius_supporting_docs_request
+#
+#     response = submit_document_to_sirius(
+#         url="http://this_url_does_not_exist/", data=body, headers=headers
+#     )
+#
+#     assert response["statusCode"] == 404
+from lambda_functions.v1.tests.helpers.use_test_data import is_valid_schema
+
+
+@pytest.mark.parametrize(
+    "example_sirius_response_code, example_sirius_response, expected_result",
+    [
+        (
+            201,
+            {
+                "type": "Report - Checklist",
+                "filename": "b11a291e6dae6_supportingDoc123.pdf",
+                "mimeType": "application/pdf",
+                "metadata": {
+                    "submission_id": 12345,
+                    "report_id": "b6279263-9834-40a6-84c1-a0e7d7e13dbf",
+                    "is_checklist": True
+                },
+                "uuid": "16aae069-99b9-494f-948b-4c2057ec5551",
+            },
+            {
+                "data": {
+                    "type": "Report - Checklist",
+                    "id": "16aae069-99b9-494f-948b-4c2057ec5551",
+                    "attributes": {
+                        "submission_id": 12345,
+                        "report_id": "b6279263-9834-40a6-84c1-a0e7d7e13dbf",
+                        "is_checklist": True
+                    },
+                }
+            },
+        ),
+        (
+            201,
+            {
+                "type": "Report - Checklist",
+                "filename": "b11a291e6dae6_supportingDoc123.pdf",
+                "mimeType": "application/pdf",
+                "metadata": {
+                    "is_checklist": True
+                },
+                "uuid": "99999999-9999-9999-9999-999999999999",
+            },
+            {
+                "data": {
+                    "type": "Report - Checklist",
+                    "id": "99999999-9999-9999-9999-999999999999",
+                    "attributes": {
+                        "is_checklist": True
+                    },
+                }
+            },
+        ),
+        (
+            500,
+            {"data": "this is all wrong"},
+            {
+                "errors": {
+                    "id": "",
+                    "code": "OPGDATA-API-SERVERERROR",
+                    "detail": "Something unexpected happened internally",
+                    "meta": {},
+                    "title": "Internal server error",
+                }
+            },
+        ),
+    ],
+)
+def test_format_sirius_response(
+    example_sirius_response_code, example_sirius_response, expected_result
+):
+    result = format_sirius_response(
+        example_sirius_response, example_sirius_response_code
+    )
+
+    assert result == expected_result
+    if example_sirius_response_code == 201:
+        assert is_valid_schema(result, "201_created_schema_checklist.json")
+    else:
+        assert is_valid_schema(result, "standard_error_schema.json")
+
+
+@pytest.mark.parametrize(
+    "case_ref, expected_response_body, expected_response_code",
+    [
+        (
+            "valid_client_id",
+            {
+                "data": {
+                    "type": "Report - Checklist",
+                    "id": "16aae069-99b9-494f-948b-4c2057ec5551",
+                    "attributes": {
+                        "submission_id": 12345,
+                    },
+                }
+            },
+            201,
+        ),
+        (
+            "invalid_client_id",
+            {
+                "errors": {
+                    "id": "",
+                    "code": "OPGDATA-API-INVALIDREQUEST",
+                    "title": "Invalid Request",
+                    "detail": "Invalid request, the data is incorrect",
+                    "meta": {},
+                }
+            },
+            400,
+        ),
+        (
+            None,
+            {
+                "errors": {
+                    "id": "",
+                    "code": "OPGDATA-API-SERVERERROR",
+                    "title": "Internal server error",
+                    "detail": "Something unexpected happened internally",
+                    "meta": {},
+                }
+            },
+            500,
+        ),
+    ],
+)
+def test_post_document_to_sirius(
+    patched_requests,
+    case_ref,
+    expected_response_body,
+    expected_response_code,
+    default_sirius_checklists_request,
+):
+    headers = {"Content-Type": "application/json"}
+    default_sirius_checklists_request["caseRecNumber"] = case_ref
+    body = json.dumps(default_sirius_checklists_request)
+
+    response = submit_document_to_sirius(
+        method="POST", url="", data=body, headers=headers
+    )
+
+    response_code, response_body = response
+
+    assert response_code == expected_response_code
+    assert response_body == expected_response_body
+
+
+@pytest.mark.parametrize(
+    "base_url, version, endpoint, url_params, expected_result",
+    [
+        (
+            "https://frontend-feature5.dev.sirius.opg.digital/api/public",
+            "v1",
+            "documents",
+            None,
+            "https://frontend-feature5.dev.sirius.opg.digital/api/public"
+            "/v1/documents",
+        ),
+        (
+            "https://frontend-feature5.dev.sirius.opg.digital/api/public",
+            "v1",
+            "clients/12345678/reports/7230e5a2-312b-4b50-bc09-f9c00c6b7f1d",
+            None,
+            "https://frontend-feature5.dev.sirius.opg.digital/api/public/v1/clients/123"
+            "45678/reports/7230e5a2-312b-4b50-bc09-f9c00c6b7f1d",
+        ),
+        (
+            "https://frontend-feature5.dev.sirius.opg.digital/api/public",
+            "v1",
+            "clients/12345678/documents",
+            {
+                "metadata[submission_id]": 11111,
+                "metadata[report_id]": "d0a43b67-3084-4a74-ab55-a7542cfadd37",
+            },
+            "https://frontend-feature5.dev.sirius.opg.digital/api/public/v1/clients/123"
+            "45678/documents?metadata[submission_id]=11111&metadata[report_id]=d0a43b67"
+            "-3084-4a74-ab55-a7542cfadd37",
+        ),
+        (
+            "https://frontend-feature5.dev.sirius.opg.digital/api/public",
+            "v1",
+            "documents",
+            {
+                "casrecnumber": "e4e497bc-7744-47ab-9d1a-345412640161",
+                "metadata[submission_id]": 11111,
+                "metadata[report_id]": "d0a43b67-3084-4a74-ab55-a7542cfadd37",
+            },
+            "https://frontend-feature5.dev.sirius.opg.digital/api/public/v1"
+            "/documents?casrecnumber=e4e497bc-7744-47ab-9d1a-345412640161"
+            "&metadata[submission_id]=11111&metadata["
+            "report_id]=d0a43b67"
+            "-3084-4a74-ab55-a7542cfadd37",
+        ),
+        (
+            "http://www.fake_url.com",
+            "6.3.1",
+            "random/endpoint/",
+            None,
+            "http://www.fake_url.com/6.3.1/random/endpoint/",
+        ),
+        ("banana", "30", "random/endpoint/", None, False,),
+    ],
+)
+def test_build_sirius_url(base_url, version, endpoint, url_params, expected_result):
+    url = build_sirius_url(base_url, version, endpoint, url_params)
+    try:
+        assert urllib.parse.unquote(url) == expected_result
+    except TypeError:
+        assert url == expected_result
+
+
+@pytest.mark.parametrize(
+    "test_content_type, test_secret_key, expected_content_type",
+    [
+        (None, "this_is_a_secret_string", "application/json"),
+        ("application/json", "this_is_a_secret_string", "application/json"),
+        ("application/pdf", "this_is_a_secret_string", "application/pdf"),
+    ],
+)
+def test_build_sirius_headers_content_type(
+    patched_get_secret, test_content_type, test_secret_key, expected_content_type
+):
+    if test_content_type:
+        headers = build_sirius_headers(content_type=test_content_type)
+    else:
+        headers = build_sirius_headers()
+
+    assert headers["Content-Type"] == expected_content_type
+
+
+def test_build_sirius_headers_auth(patched_get_secret):
+    headers = build_sirius_headers()
+    token = headers["Authorization"].split()[1]
+
+    try:
+        jwt.decode(token.encode("UTF-8"), "this_is_a_secret_string", algorithms="HS256")
+    except DecodeError as e:
+        pytest.fail(f"JWT is not encoded properly: {e}")
+
+    with pytest.raises(DecodeError):
+        jwt.decode(token.encode("UTF-8"), "this_is_the_wrong_key", algorithms="HS256")
+
+
+@pytest.mark.parametrize(
+    "url, expected_result",
+    [
+        ("https://frontend-feature5.dev.sirius.opg.digital/", [{"data": "success"}]),
+        ("https://fake_url.com", None),
+    ],
+)
+def test_get_endpoint(
+    patched_requests, patched_get_secret, url, expected_result,
+):
+    result = send_get_to_sirius(url)
+    print(result)
+
+    assert result == expected_result

--- a/lambda_functions/v1/tests/flask_app/conftest.py
+++ b/lambda_functions/v1/tests/flask_app/conftest.py
@@ -59,6 +59,22 @@ def default_report_request_body_flask():
 
 
 @pytest.fixture(autouse=True)
+def default_sirius_checklist_request(
+    default_request_case_ref, default_request_report_id
+):
+    return {
+        "type": "Report - Checklist",
+        "caseRecNumber": default_request_case_ref,
+        "metadata": {"submission_id": 231231, "report_id": default_request_report_id},
+        "file": {
+            "name": "Supporting_Document_111.pdf",
+            "source": "string",
+            "type": "application/pdf",
+        },
+    }
+
+
+@pytest.fixture(autouse=True)
 def default_sirius_supporting_docs_request(
     default_request_case_ref, default_request_report_id
 ):

--- a/lambda_functions/v1/tests/flask_app/routes/cases_checklist_post_endpoint.py
+++ b/lambda_functions/v1/tests/flask_app/routes/cases_checklist_post_endpoint.py
@@ -7,10 +7,10 @@ def case_success() -> CaseData:
     test_data = {
         "checklist": {
             "data": {
-                "type": "supportingdocuments",
+                "type": "checklists",
                 "attributes": {"submission_id": 12345},
                 "file": {
-                    "name": "Report_1234567T_2018_2019_11111.pdf",
+                    "name": "Checklist.pdf",
                     "mimetype": "application/pdf",
                     "source": "string",
                 },
@@ -29,6 +29,46 @@ def case_success() -> CaseData:
             "id": "5a8b1a26-8296-4373-ae61-f8d0b250e773",
             # "type": "Report - Checklist",
             "type": "checklists",
+        }
+    }
+
+    return (
+        test_data,
+        test_headers,
+        test_report_id,
+        test_case_ref,
+        expected_response_status_code,
+        expected_response_data,
+    )
+
+
+@case_name("Successful post to checklist endpoint no submission id")
+def case_success_no_submission_id() -> CaseData:
+
+    test_data = {
+        "checklist": {
+            "data": {
+                "type": "checklists",
+                "attributes": {},
+                "file": {
+                    "name": "Checklist.pdf",
+                    "mimetype": "application/pdf",
+                    "source": "string",
+                },
+            }
+        }
+    }
+    test_case_ref = 1111
+    test_report_id = "99999999-9999-9999-9999-999999999999"
+
+    test_headers = {"Content-Type": "application/json"}
+
+    expected_response_status_code = 201
+    expected_response_data = {
+        "data": {
+            "attributes": {"parent_id": None, "submission_id": None},
+            "id": "5a8b1a26-8296-4373-ae61-f8d0b250e773",
+            "type": "Report - Checklist",
         }
     }
 

--- a/lambda_functions/v1/tests/flask_app/routes/cases_checklist_post_endpoint.py
+++ b/lambda_functions/v1/tests/flask_app/routes/cases_checklist_post_endpoint.py
@@ -27,7 +27,6 @@ def case_success() -> CaseData:
         "data": {
             "attributes": {"parent_id": None, "submission_id": 12345},
             "id": "5a8b1a26-8296-4373-ae61-f8d0b250e773",
-            # "type": "Report - Checklist",
             "type": "checklists",
         }
     }
@@ -68,7 +67,7 @@ def case_success_no_submission_id() -> CaseData:
         "data": {
             "attributes": {"parent_id": None, "submission_id": None},
             "id": "5a8b1a26-8296-4373-ae61-f8d0b250e773",
-            "type": "Report - Checklist",
+            "type": "checklists",
         }
     }
 

--- a/lambda_functions/v1/tests/flask_app/routes/cases_checklist_put_endpoint.py
+++ b/lambda_functions/v1/tests/flask_app/routes/cases_checklist_put_endpoint.py
@@ -7,10 +7,10 @@ def case_success() -> CaseData:
     test_data = {
         "checklist": {
             "data": {
-                "type": "supportingdocuments",
+                "type": "checklists",
                 "attributes": {"submission_id": 12345},
                 "file": {
-                    "name": "Report_1234567T_2018_2019_11111.pdf",
+                    "name": "Checklist.pdf",
                     "mimetype": "application/pdf",
                     "source": "string",
                 },
@@ -30,6 +30,48 @@ def case_success() -> CaseData:
             "id": "5a8b1a26-8296-4373-ae61-f8d0b250e773",
             # "type": "Report - Checklist",
             "type": "checklists",
+        }
+    }
+
+    return (
+        test_data,
+        test_headers,
+        test_report_id,
+        test_checklist_id,
+        test_case_ref,
+        expected_response_status_code,
+        expected_response_data,
+    )
+
+
+@case_name("Successful PUT to checklist endpoint no submission")
+def case_success_no_submission_id() -> CaseData:
+
+    test_data = {
+        "checklist": {
+            "data": {
+                "type": "checklists",
+                "attributes": {},
+                "file": {
+                    "name": "Checklist.pdf",
+                    "mimetype": "application/pdf",
+                    "source": "string",
+                },
+            }
+        }
+    }
+    test_case_ref = 1111
+    test_report_id = "99999999-9999-9999-9999-999999999999"
+    test_checklist_id = "ea35592e-a1a7-4f87-98e9-1519bcb086ac"
+
+    test_headers = {"Content-Type": "application/json"}
+
+    expected_response_status_code = 201
+    expected_response_data = {
+        "data": {
+            "attributes": {"parent_id": None, "submission_id": None},
+            "id": "5a8b1a26-8296-4373-ae61-f8d0b250e773",
+            "type": "Report - Checklist",
         }
     }
 

--- a/lambda_functions/v1/tests/flask_app/routes/cases_checklist_put_endpoint.py
+++ b/lambda_functions/v1/tests/flask_app/routes/cases_checklist_put_endpoint.py
@@ -28,7 +28,6 @@ def case_success() -> CaseData:
         "data": {
             "attributes": {"parent_id": None, "submission_id": 12345},
             "id": "5a8b1a26-8296-4373-ae61-f8d0b250e773",
-            # "type": "Report - Checklist",
             "type": "checklists",
         }
     }
@@ -71,7 +70,7 @@ def case_success_no_submission_id() -> CaseData:
         "data": {
             "attributes": {"parent_id": None, "submission_id": None},
             "id": "5a8b1a26-8296-4373-ae61-f8d0b250e773",
-            "type": "Report - Checklist",
+            "type": "checklists",
         }
     }
 

--- a/lambda_functions/v1/tests/test_data/201_created_schema_checklist.json
+++ b/lambda_functions/v1/tests/test_data/201_created_schema_checklist.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "properties": {
+    "data": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "attributes": {
+          "type": "object",
+          "properties": {
+          }
+        }
+      },
+      "required": [
+        "type",
+        "id",
+        "attributes"
+      ]
+    },
+    "meta": {
+      "type": "object"
+    }
+  },
+  "required": [
+    "data"
+  ]
+}

--- a/lambda_functions/v1/tests/test_data/checklists_event.json
+++ b/lambda_functions/v1/tests/test_data/checklists_event.json
@@ -1,0 +1,74 @@
+{
+	"resource": "/clients/{caseref}/reports/{id}/checklists",
+	"path": "/v1/clients/22814959/reports/99999999-9999-9999-9999-999999999999/checklists",
+	"httpMethod": "POST",
+	"headers": {
+		"accept-encoding": "gzip",
+		"content-type": "application/json",
+		"Host": "in235.dev.deputy-reporting.api.opg.service.justice.gov.uk",
+		"User-Agent": "Go-http-client/2.0",
+		"x-amz-date": "20200403T160145Z",
+		"x-amz-security-token": "FwoGZXIvYXdzEGkaDOF2jr9soZCYb4WvciK7AZ26nm40HIRTwbc+vBdOLpJR2H3WHr2hkuho3bSIS+53FbVFGfM2goRtGsalZNmW/iaNv87SxEe8crVMb56vazj3qcwiKlyQH69Ex0DLdcCwpP3NdWTDnuIntv1rNMoUEqSDWzEON6HHrv8XS2GpO5x1kGfEtc+lWTFjZ+kWO5um0dGNsN3SRHsSjGzsSYh2kEs6l8rX6MGznAII2kOCW4SyVQpJfjBbL6N/TJmJQqufC9luzAU9FuX5zPoo6rud9AUyLTr2rlkoswkyOE1qlXpjFwreG+Q9gq8v+XZWVJ0eZISMk+Xwn8PjlWc80DtusQ==",
+		"X-Amzn-Trace-Id": "Root=1-5e875dea-c09eeb1c9397fcfbdd1d0971",
+		"X-Forwarded-For": "92.9.72.100",
+		"X-Forwarded-Port": "443",
+		"X-Forwarded-Proto": "https"
+	},
+	"multiValueHeaders": {
+		"accept-encoding": ["gzip"],
+		"content-type": ["application/json"],
+		"Host": ["in235.dev.deputy-reporting.api.opg.service.justice.gov.uk"],
+		"User-Agent": ["Go-http-client/2.0"],
+		"x-amz-date": ["20200403T160145Z"],
+		"x-amz-security-token": ["FwoGZXIvYXdzEGkaDOF2jr9soZCYb4WvciK7AZ26nm40HIRTwbc+vBdOLpJR2H3WHr2hkuho3bSIS+53FbVFGfM2goRtGsalZNmW/iaNv87SxEe8crVMb56vazj3qcwiKlyQH69Ex0DLdcCwpP3NdWTDnuIntv1rNMoUEqSDWzEON6HHrv8XS2GpO5x1kGfEtc+lWTFjZ+kWO5um0dGNsN3SRHsSjGzsSYh2kEs6l8rX6MGznAII2kOCW4SyVQpJfjBbL6N/TJmJQqufC9luzAU9FuX5zPoo6rud9AUyLTr2rlkoswkyOE1qlXpjFwreG+Q9gq8v+XZWVJ0eZISMk+Xwn8PjlWc80DtusQ=="],
+		"X-Amzn-Trace-Id": ["Root=1-5e875dea-c09eeb1c9397fcfbdd1d0971"],
+		"X-Forwarded-For": ["92.9.72.100"],
+		"X-Forwarded-Port": ["443"],
+		"X-Forwarded-Proto": ["https"]
+	},
+	"queryStringParameters": null,
+	"multiValueQueryStringParameters": null,
+	"pathParameters": {
+		"caseref": "22814959",
+		"id": "99999999-9999-9999-9999-999999999999"
+	},
+	"stageVariables": {
+		"supporting_docs_name": "sirius-supporting_docs-in235-v1",
+		"healthcheck_function_name": "sirius-healthcheck-in235-v1",
+		"reports_function_name": "sirius-reports-in235-v1",
+		"checklists_function_name": "sirius-checklists-in235-v1"
+	},
+	"requestContext": {
+		"resourceId": "5h9841",
+		"resourcePath": "/clients/{caseref}/reports/{id}/checklists",
+		"operationName": "app.addReportSupportingDocument",
+		"httpMethod": "POST",
+		"extendedRequestId": "KaucoFSTDoEFmcQ=",
+		"requestTime": "03/Apr/2020:16:01:46 +0000",
+		"path": "/v1/clients/22814959/reports/99999999-9999-9999-9999-999999999999/checklists",
+		"accountId": "288342028542",
+		"protocol": "HTTP/1.1",
+		"stage": "v1",
+		"domainPrefix": "in235",
+		"requestTimeEpoch": 1585929706337,
+		"requestId": "5b3e334d-e983-44e0-9b69-e9d87b12e7e9",
+		"identity": {
+			"cognitoIdentityPoolId": null,
+			"accountId": "248804316466",
+			"cognitoIdentityId": null,
+			"caller": "AROATT3PESUZKDAX5FJOA:1585929705472551000",
+			"sourceIp": "92.9.72.100",
+			"principalOrgId": "o-b2fpbzyd95",
+			"accessKey": "AAAAAAAAAAAAAAAAAAAA",
+			"cognitoAuthenticationType": null,
+			"cognitoAuthenticationProvider": null,
+			"userArn": "arn:aws:sts::248804316466:assumed-role/operator/1585929705472551000",
+			"userAgent": "Go-http-client/2.0",
+			"user": "AROATT3PESUZKDAX5FJOA:1585929705472551000"
+		},
+		"domainName": "in235.dev.deputy-reporting.api.opg.service.justice.gov.uk",
+		"apiId": "ak1vp6g219"
+	},
+	"body":"{\n\"checklist\":{\n\"data\":{\n\"type\":\"checklists\",\n\"attributes\":{\n\"submission_id\":12345\n},\n\"file\":{\n\"name\":\"checklist.pdf\",\n\"mimetype\":\"application/pdf\",\n\"source\":\"nc29tZV9jb250ZW50\"\n}\n}\n}\n}\n",
+	"isBase64Encoded":false
+}


### PR DESCRIPTION
## Purpose

Some checklists are sent in response to non-digital reports, which have no report submission ID. It should still be possible for the client to submit a checklist against the client id, and have it appear at the top of their documents list

[https://opgtransform.atlassian.net/browse/IN-280](https://opgtransform.atlassian.net/browse/IN-280)

## Approach

Remove any requirement that attributes["submission_id"] / metadata["submission_id"] be provided
Digideps are also going to send a dummy Report Id ("99999999-9999-9999-9999-999999999999"). This will actually pass all validation as it is a valid UUID

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered_

## Checklist

* [x] I have performed a self-review of my own code
* [x] I have added relevant logging with appropriate levels to my code
* [x] I have updated documentation where relevant
* [x] I have added tests to prove my work
* [ ] The product team have tested these changes
* [ ] I have run the integration tests (results below)


