### PR TITLE
IN-235 merge into v2 structure

### DIFF
--- a/lambda_functions/v1/tests/checklists/test_checklists_endpoint.py
+++ b/lambda_functions/v1/tests/checklists/test_checklists_endpoint.py
@@ -15,9 +15,7 @@ from lambda_functions.v1.tests.helpers.use_test_data import (
     load_data,
     build_aws_event,
 )
-from lambda_functions.v1.tests.checklists import (
-    checklists_endpoint_test_cases,
-)
+from lambda_functions.v1.tests.checklists import checklists_endpoint_test_cases
 
 
 def test_lambda_handler(
@@ -61,7 +59,7 @@ def test_transform_event_to_sirius_request(
     default_checklists_request_body,
     default_request_case_ref,
     default_request_report_id,
-    default_sirius_checklists_request
+    default_sirius_checklists_request,
 ):
     path_params = {"caseref": default_request_case_ref, "id": default_request_report_id}
     event = build_aws_event(
@@ -80,9 +78,12 @@ def test_transform_event_to_sirius_request_with_no_report_submission(
     default_request_case_ref,
     nondigital_request_report_id,
     checklists_request_body_with_no_report_submission,
-    sirius_checklists_request_with_no_report_submission
+    sirius_checklists_request_with_no_report_submission,
 ):
-    path_params = {"caseref": default_request_case_ref, "id": nondigital_request_report_id}
+    path_params = {
+        "caseref": default_request_case_ref,
+        "id": nondigital_request_report_id,
+    }
     event = build_aws_event(
         event_body=json.dumps(checklists_request_body_with_no_report_submission),
         event_path_parementers=path_params,
@@ -101,7 +102,9 @@ def test_sirius_request_has_report_id_from_path(
     default_request_report_id,
     default_sirius_checklists_request,
 ):
-    default_checklists_request_body["checklist"]["data"]["attributes"]["report_id"] = "uuid_from_attributes"
+    default_checklists_request_body["checklist"]["data"]["attributes"][
+        "report_id"
+    ] = "uuid_from_attributes"
     path_params = {"caseref": default_request_case_ref, "id": "uuid_from_path"}
     event = build_aws_event(
         event_body=json.dumps(default_checklists_request_body),

--- a/lambda_functions/v1/tests/checklists/test_checklists_sirius_service.py
+++ b/lambda_functions/v1/tests/checklists/test_checklists_sirius_service.py
@@ -29,7 +29,7 @@ from lambda_functions.v1.tests.helpers.use_test_data import is_valid_schema
                 "metadata": {
                     "submission_id": 12345,
                     "report_id": "b6279263-9834-40a6-84c1-a0e7d7e13dbf",
-                    "is_checklist": True
+                    "is_checklist": True,
                 },
                 "uuid": "16aae069-99b9-494f-948b-4c2057ec5551",
             },
@@ -40,7 +40,7 @@ from lambda_functions.v1.tests.helpers.use_test_data import is_valid_schema
                     "attributes": {
                         "submission_id": 12345,
                         "report_id": "b6279263-9834-40a6-84c1-a0e7d7e13dbf",
-                        "is_checklist": True
+                        "is_checklist": True,
                     },
                 }
             },
@@ -51,18 +51,14 @@ from lambda_functions.v1.tests.helpers.use_test_data import is_valid_schema
                 "type": "Report - Checklist",
                 "filename": "b11a291e6dae6_supportingDoc123.pdf",
                 "mimeType": "application/pdf",
-                "metadata": {
-                    "is_checklist": True
-                },
+                "metadata": {"is_checklist": True},
                 "uuid": "99999999-9999-9999-9999-999999999999",
             },
             {
                 "data": {
                     "type": "Report - Checklist",
                     "id": "99999999-9999-9999-9999-999999999999",
-                    "attributes": {
-                        "is_checklist": True
-                    },
+                    "attributes": {"is_checklist": True},
                 }
             },
         ),
@@ -104,9 +100,7 @@ def test_format_sirius_response(
                 "data": {
                     "type": "Report - Checklist",
                     "id": "16aae069-99b9-494f-948b-4c2057ec5551",
-                    "attributes": {
-                        "submission_id": 12345,
-                    },
+                    "attributes": {"submission_id": 12345},
                 }
             },
             201,

--- a/lambda_functions/v2/functions/documents/app/api/checklists.py
+++ b/lambda_functions/v2/functions/documents/app/api/checklists.py
@@ -1,4 +1,5 @@
 import json
+import copy
 
 from . import sirius_service
 from .helpers import custom_logger
@@ -45,7 +46,10 @@ def transform_payload_to_sirius_post_request(
         "file": {"name": file_name, "source": file_source, "type": file_type},
     }
 
-    logger.debug(f"Sirius Payload: {payload}")
+    debug_payload = copy.deepcopy(payload)
+    debug_payload["file"]["source"] = "REDACTED"
+
+    logger.debug(f"Sirius Payload: {debug_payload}")
 
     return json.dumps(payload)
 

--- a/lambda_functions/v2/functions/documents/app/api/reports.py
+++ b/lambda_functions/v2/functions/documents/app/api/reports.py
@@ -1,13 +1,13 @@
 import json
+import copy
 
 from . import sirius_service
-from .helpers import custom_logger
+from .helpers import custom_logger, handle_file_source
 
 logger = custom_logger("reports")
 
 
 def endpoint_handler(data, caseref):
-
     sirius_payload = transform_payload_data_to_sirius_request(
         data=data, caseref=caseref
     )
@@ -32,7 +32,7 @@ def transform_payload_data_to_sirius_request(data, caseref=None):
     metadata = request_body["report"]["data"]["attributes"]
     file_name = request_body["report"]["data"]["file"]["name"]
     file_type = request_body["report"]["data"]["file"]["mimetype"]
-    file_source = request_body["report"]["data"]["file"]["source"]
+    file_source = handle_file_source(file=request_body["report"]["data"]["file"])
 
     payload = {
         "type": "Report",
@@ -40,6 +40,9 @@ def transform_payload_data_to_sirius_request(data, caseref=None):
         "metadata": metadata,
         "file": {"name": file_name, "source": file_source, "type": file_type},
     }
-    logger.debug(f"Sirius Payload: {payload}")
+
+    debug_payload = copy.deepcopy(payload)
+    debug_payload["file"]["source"] = "REDACTED"
+    logger.debug(f"Sirius Payload: {debug_payload}")
 
     return json.dumps(payload)

--- a/lambda_functions/v2/functions/documents/app/api/supporting_docs.py
+++ b/lambda_functions/v2/functions/documents/app/api/supporting_docs.py
@@ -1,8 +1,9 @@
 import json
 import os
+import copy
 
 from . import sirius_service
-from .helpers import custom_logger
+from .helpers import custom_logger, handle_file_source
 
 logger = custom_logger("supporting_docs")
 
@@ -36,7 +37,9 @@ def transform_payload_to_sirius_post_request(
     metadata["report_id"] = report_id
     file_name = request_body["supporting_document"]["data"]["file"]["name"]
     file_type = request_body["supporting_document"]["data"]["file"]["mimetype"]
-    file_source = request_body["supporting_document"]["data"]["file"]["source"]
+    file_source = handle_file_source(
+        file=request_body["supporting_document"]["data"]["file"]
+    )
 
     payload = {
         "type": "Report - General",
@@ -48,7 +51,10 @@ def transform_payload_to_sirius_post_request(
     if parent_id:
         payload["parentUuid"] = parent_id
 
-    logger.debug(f"Sirius Payload: {payload}")
+    debug_payload = copy.deepcopy(payload)
+    debug_payload["file"]["source"] = "REDACTED"
+
+    logger.debug(f"Sirius Payload: {debug_payload}")
 
     return json.dumps(payload)
 

--- a/lambda_functions/v2/tests/conftest.py
+++ b/lambda_functions/v2/tests/conftest.py
@@ -1,4 +1,5 @@
 import json
+import os
 
 import pytest
 import requests
@@ -6,6 +7,17 @@ import requests
 import lambda_functions
 from lambda_functions.v2.functions.documents.app import api
 from lambda_functions.v2.functions.documents.app.api import sirius_service
+
+
+@pytest.fixture(autouse=True)
+def aws_credentials():
+    os.environ["AWS_ACCESS_KEY_ID"] = "testing"
+    os.environ["AWS_SECRET_ACCESS_KEY"] = "testing"
+    os.environ["AWS_SECURITY_TOKEN"] = "testing"
+    os.environ["AWS_SESSION_TOKEN"] = "testing"
+    os.environ["AWS_DEFAULT_REGION"] = "eu-west-1"
+    os.environ["AWS_XRAY_CONTEXT_MISSING"] = "LOG_ERROR"
+
 
 test_data = {
     "valid_clients": ["valid_client_id", "0319392T", "12345678", "22814959"],
@@ -139,7 +151,12 @@ def default_request_report_id():
 def mock_env_setup(monkeypatch):
     monkeypatch.setenv("BASE_URL", "http://localhost:8080")
     monkeypatch.setenv("SIRIUS_BASE_URL", "http://not-really-sirius.com")
+    monkeypatch.setenv("SIRIUS_PUBLIC_API_URL", "api/public/v1/")
     monkeypatch.setenv("LOGGER_LEVEL", "DEBUG")
+    monkeypatch.setenv("DIGIDEPS_S3_BUCKET", "some-s3-bucket")
+    monkeypatch.setenv(
+        "DIGIDEPS_S3_ROLE_ARN", "arn:aws:iam::123456789012:role/s3-read-role"
+    )
     monkeypatch.setenv("JWT_SECRET", "THIS_IS_MY_SECRET_KEY")
     monkeypatch.setenv("ENVIRONMENT", "development")
     monkeypatch.setenv("SESSION_DATA", "publicapi@opgtest.com")
@@ -344,7 +361,7 @@ def patched_post(monkeypatch, request):
 
 
 # @pytest.fixture(autouse=False, params=[400, 404, 500])
-@pytest.fixture(autouse=False)
+@pytest.fixture(autouse=False, params=[400])
 def patched_post_broken_sirius(request, monkeypatch):
     def mock_post_to_broken_sirius(*args, **kwargs):
         print("MOCK POST TO BROKEN SIRIUS")

--- a/lambda_functions/v2/tests/helpers/test_file.txt
+++ b/lambda_functions/v2/tests/helpers/test_file.txt
@@ -1,0 +1,1 @@
+this is a test file

--- a/lambda_functions/v2/tests/helpers/test_get_encoded_s3_object.py
+++ b/lambda_functions/v2/tests/helpers/test_get_encoded_s3_object.py
@@ -1,0 +1,89 @@
+import base64
+import os
+
+import boto3
+import pytest
+from moto import mock_s3
+
+from lambda_functions.v2.functions.documents.app.api.helpers import (
+    get_encoded_s3_object,
+)
+
+"""
+Tests to add:
+
+* get file by key
+* try to get file but bucket doesn't exist
+* try to get file but key doesn't exist
+* try to get file but encoding breaks
+try to get file but saving locally fails
+try to get file but opening locally fails
+"""
+
+
+@pytest.mark.parametrize(
+    "test_bucket, test_key, expected_result",
+    [
+        ("valid_bucket", "test_file_on_aws.txt", "overwritten by test"),
+        pytest.param(
+            "invalid_bucket",
+            "test_file_on_aws.txt",
+            "overwritten by test",
+            marks=pytest.mark.xfail(reason="Not handled"),
+        ),
+        pytest.param(
+            "valid_bucket",
+            "not_a_file_on_aws.txt",
+            "overwritten by test",
+            marks=pytest.mark.xfail(reason="Not handled"),
+        ),
+    ],
+)
+def test_get_encoded_s3_object(test_bucket, test_key, expected_result):
+    path_to_current_file = os.path.realpath(__file__)
+    current_directory = os.path.split(path_to_current_file)[0]
+    test_file = os.path.join(current_directory, "test_file.txt")
+
+    with open(test_file, "rb") as image_file:
+        expected_result = base64.b64encode(image_file.read()).decode("utf-8")
+
+    with mock_s3():
+        s3_client = boto3.client("s3", region_name="eu-west-1")
+        s3_client.create_bucket(Bucket="valid_bucket")
+        s3_client.upload_file(test_file, "valid_bucket", "test_file_on_aws.txt")
+
+        result = get_encoded_s3_object(
+            s3_client=s3_client, bucket=test_bucket, key=test_key
+        )
+
+        assert result == expected_result
+
+
+@pytest.mark.xfail(reason="No error handling")
+def test_broken_encoding(monkeypatch):
+    test_bucket = "valid_bucket"
+    test_key = "test_file_on_aws.txt"
+
+    def mock_broken_base64encode(*args, **kwargs):
+        print("Mock b64encode")
+        return "I am not encoded"
+
+    monkeypatch.setattr(base64, "b64encode", mock_broken_base64encode)
+
+    path_to_current_file = os.path.realpath(__file__)
+    current_directory = os.path.split(path_to_current_file)[0]
+    test_file = os.path.join(current_directory, "test_file.txt")
+
+    with open(test_file, "rb") as image_file:
+        expected_result = base64.b64encode(image_file.read()).decode("utf-8")
+
+    with mock_s3():
+        s3_client = boto3.client("s3", region_name="eu-west-1")
+        s3_client.create_bucket(Bucket=test_bucket)
+        s3_client.upload_file(test_file, test_bucket, test_key)
+
+        result = get_encoded_s3_object(
+            s3_client=s3_client, bucket=test_bucket, key=test_key
+        )
+
+        assert result == expected_result

--- a/lambda_functions/v2/tests/helpers/test_handle_file_source.py
+++ b/lambda_functions/v2/tests/helpers/test_handle_file_source.py
@@ -1,0 +1,170 @@
+import pytest
+
+from lambda_functions.v2.functions.documents.app import api
+from lambda_functions.v2.functions.documents.app.api.helpers import handle_file_source
+
+"""
+Tests to add:
+
+* file is sent
+* s3 ref is sent
+* neither file or s3 is sent FAILS
+* both file and s3 are sent
+* DIGIDEPS_S3_BUCKET is not set FAILS
+* get_encoded_s3_object fails FAILS
+* get_digideps_s3_client fails FAILS
+
+can't think of any more, this is just a commit to test Circle CI
+"""
+
+
+@pytest.mark.parametrize(
+    "test_dict, expected_result",
+    [
+        (
+            {
+                "name": "test_file_name",
+                "type": "application/pdf",
+                "s3_reference": "link_to_file",
+            },
+            "this is a base64 encoded file from s3",
+        ),
+        (
+            {
+                "name": "test_file_name",
+                "type": "application/pdf",
+                "source": "this is a base64 encoded file",
+            },
+            "this is a base64 encoded file",
+        ),
+        pytest.param(
+            {"name": "test_file_name", "type": "application/pdf"},
+            "this is a base64 encoded file from s3",
+            marks=pytest.mark.xfail(reason="Not handled"),
+        ),
+        (
+            {
+                "name": "test_file_name",
+                "type": "application/pdf",
+                "s3_reference": "link_to_file",
+                "source": "this is a base64 encoded file",
+            },
+            "this is a base64 encoded file",
+        ),
+    ],
+)
+def test_handle_file_source(monkeypatch, test_dict, expected_result):
+    def mock_get_encoded_s3_object(*args, **kwwargs):
+        print("mock_get_encoded_s3_object")
+        return "this is a base64 encoded file from s3"
+
+    monkeypatch.setattr(
+        api.helpers, "get_encoded_s3_object", mock_get_encoded_s3_object
+    )
+
+    def mock_get_digideps_s3_client(*args, **kwargs):
+        print("mock_get_digideps_s3_client")
+        return "client"
+
+    monkeypatch.setattr(
+        api.helpers, "get_digideps_s3_client", mock_get_digideps_s3_client
+    )
+
+    monkeypatch.setenv("DIGIDEPS_S3_BUCKET", "secret")
+
+    result = handle_file_source(test_dict)
+
+    assert result == expected_result
+
+
+@pytest.mark.xfail(reason="No error handling")
+def test_env_var_not_set(monkeypatch):
+    def mock_get_encoded_s3_object(*args, **kwwargs):
+        print("mock_get_encoded_s3_object")
+        return "this is a base64 encoded file from s3"
+
+    monkeypatch.setattr(
+        api.helpers, "get_encoded_s3_object", mock_get_encoded_s3_object
+    )
+
+    def mock_get_digideps_s3_client(*args, **kwargs):
+        print("mock_get_digideps_s3_client")
+        return "client"
+
+    monkeypatch.setattr(
+        api.helpers, "get_digideps_s3_client", mock_get_digideps_s3_client
+    )
+
+    test_dict = {
+        "name": "test_file_name",
+        "type": "application/pdf",
+        "s3_reference": "link_to_file",
+    }
+
+    monkeypatch.delenv("DIGIDEPS_S3_BUCKET")
+
+    result = handle_file_source(test_dict)
+
+    assert result == "nice error handling ere"
+
+
+@pytest.mark.xfail(reason="No error handling")
+def test_get_encoded_s3_object_fails(monkeypatch):
+    def mock_get_encoded_s3_object_fails(*args, **kwwargs):
+        print("mock_get_encoded_s3_object")
+        raise Exception
+
+    monkeypatch.setattr(
+        api.helpers, "get_encoded_s3_object", mock_get_encoded_s3_object_fails
+    )
+
+    def mock_get_digideps_s3_client(*args, **kwargs):
+        print("mock_get_digideps_s3_client")
+        return "client"
+
+    monkeypatch.setattr(
+        api.helpers, "get_digideps_s3_client", mock_get_digideps_s3_client
+    )
+
+    test_dict = {
+        "name": "test_file_name",
+        "type": "application/pdf",
+        "s3_reference": "link_to_file",
+    }
+
+    monkeypatch.setenv("DIGIDEPS_S3_BUCKET", "secret")
+
+    result = handle_file_source(test_dict)
+
+    assert result == "nice error handling here"
+
+
+@pytest.mark.xfail(reason="No error handling")
+def test_get_digideps_s3_client_fails(monkeypatch):
+    def mock_get_encoded_s3_object(*args, **kwwargs):
+        print("mock_get_encoded_s3_object")
+        return "this is a base64 encoded file from s3"
+
+    monkeypatch.setattr(
+        api.helpers, "get_encoded_s3_object", mock_get_encoded_s3_object
+    )
+
+    def mock_get_digideps_s3_client_fails(*args, **kwargs):
+        print("mock_get_digideps_s3_client")
+        raise Exception
+
+    monkeypatch.setattr(
+        api.helpers, "get_digideps_s3_client", mock_get_digideps_s3_client_fails
+    )
+
+    test_dict = {
+        "name": "test_file_name",
+        "type": "application/pdf",
+        "s3_reference": "link_to_file",
+    }
+
+    monkeypatch.setenv("DIGIDEPS_S3_BUCKET", "secret")
+
+    result = handle_file_source(test_dict)
+
+    assert result == "nice error handling here"

--- a/lambda_functions/v2/tests/routes/cases_reports_endpoint.py
+++ b/lambda_functions/v2/tests/routes/cases_reports_endpoint.py
@@ -1,3 +1,4 @@
+import pytest
 from pytest_cases import CaseData, case_name, case_tags, cases_generator
 
 """
@@ -57,6 +58,145 @@ def case_success() -> CaseData:
     )
 
 
+@case_tags("endpoint", "success")
+@case_name("Successful post to Docs API using s3 ref")
+def case_success_s3() -> CaseData:
+
+    test_data = {
+        "report": {
+            "data": {
+                "type": "reports",
+                "attributes": {
+                    "submission_id": 12345,
+                    "reporting_period_from": "2019-01-01",
+                    "reporting_period_to": "2019-12-31",
+                    "year": 2019,
+                    "date_submitted": "2020-01-03T09:30:00.001Z",
+                    "type": "PF",
+                },
+                "file": {
+                    "name": "Report_1234567T_2018_2019_11111.pdf",
+                    "mimetype": "application/pdf",
+                    "s3_reference": "this_is_a_file_on_s3.pdf",
+                },
+            }
+        }
+    }
+    test_case_ref = 1111
+
+    test_headers = {"Content-Type": "application/json"}
+
+    expected_response_status_code = 201
+    expected_response_data = {
+        "data": {
+            "attributes": {"submission_id": 12345, "parent_id": None},
+            "id": "5a8b1a26-8296-4373-ae61-f8d0b250e773",
+            "type": "reports",
+        }
+    }
+
+    return (
+        test_data,
+        test_headers,
+        test_case_ref,
+        expected_response_status_code,
+        expected_response_data,
+    )
+
+
+@case_tags("endpoint", "success")
+@case_name("Successful post to Docs API - with both source and s3 ref")
+def case_both_s3_and_file() -> CaseData:
+
+    test_data = {
+        "report": {
+            "data": {
+                "type": "reports",
+                "attributes": {
+                    "submission_id": 12345,
+                    "reporting_period_from": "2019-01-01",
+                    "reporting_period_to": "2019-12-31",
+                    "year": 2019,
+                    "date_submitted": "2020-01-03T09:30:00.001Z",
+                    "type": "PF",
+                },
+                "file": {
+                    "name": "Report_1234567T_2018_2019_11111.pdf",
+                    "mimetype": "application/pdf",
+                    "source": "string",
+                    "s3_reference": "this_is_a_file_on_s3.pdf",
+                },
+            }
+        }
+    }
+    test_case_ref = 1111
+
+    test_headers = {"Content-Type": "application/json"}
+
+    expected_response_status_code = 201
+    expected_response_data = {
+        "data": {
+            "attributes": {"submission_id": 12345, "parent_id": None},
+            "id": "5a8b1a26-8296-4373-ae61-f8d0b250e773",
+            "type": "reports",
+        }
+    }
+
+    return (
+        test_data,
+        test_headers,
+        test_case_ref,
+        expected_response_status_code,
+        expected_response_data,
+    )
+
+
+@pytest.mark.xfail(reason="No error handling")
+@case_tags("endpoint", "error")
+@case_name("Fail post to Docs API - with neither source nor s3 ref")
+def case_neither_s3_nor_file() -> CaseData:
+
+    test_data = {
+        "report": {
+            "data": {
+                "type": "reports",
+                "attributes": {
+                    "submission_id": 12345,
+                    "reporting_period_from": "2019-01-01",
+                    "reporting_period_to": "2019-12-31",
+                    "year": 2019,
+                    "date_submitted": "2020-01-03T09:30:00.001Z",
+                    "type": "PF",
+                },
+                "file": {
+                    "name": "Report_1234567T_2018_2019_11111.pdf",
+                    "mimetype": "application/pdf",
+                },
+            }
+        }
+    }
+    test_case_ref = 1111
+
+    test_headers = {"Content-Type": "application/json"}
+
+    expected_response_status_code = 400
+    expected_response_data = {
+        "data": {
+            "attributes": {"submission_id": 12345, "parent_id": None},
+            "id": "5a8b1a26-8296-4373-ae61-f8d0b250e773",
+            "type": "reports",
+        }
+    }
+
+    return (
+        test_data,
+        test_headers,
+        test_case_ref,
+        expected_response_status_code,
+        expected_response_data,
+    )
+
+
 @case_tags("endpoint", "error")
 @case_name("Case ref doesn't exist in Sirius")
 def case_bad_params() -> CaseData:
@@ -97,95 +237,11 @@ def case_bad_params() -> CaseData:
     )
 
 
-# @case_tags("endpoint")
-# @case_name("Bad payload sent to Docs API - no submission_id")
-# def case_bad_data_attributes() -> CaseData:
-#
-#     test_data = {
-#         "report": {
-#             "data": {
-#                 "type": "reports",
-#                 "attributes": {
-#                     "reporting_period_from": "2019-01-01",
-#                     "reporting_period_to": "2019-12-31",
-#                     "year": 2019,
-#                     "date_submitted": "2020-01-03T09:30:00.001Z",
-#                     "type": "PF",
-#                 },
-#                 "file": {
-#                     "name": "Report_1234567T_2018_2019_11111.pdf",
-#                     "mimetype": "application/pdf",
-#                     "source": "string",
-#                 },
-#             }
-#         }
-#     }
-#     test_case_ref = 1111
-#
-#     test_headers = {"Content-Type": "application/json"}
-#
-#     expected_response_status_code = 400
-#     expected_response_data = "unable to parse payload"
-#
-#     return (
-#         test_data,
-#         test_headers,
-#         test_case_ref,
-#         expected_response_status_code,
-#         expected_response_data,
-#     )
-
-
-# @case_tags("endpoint")
-# @cases_generator(
-#     "Bad payload sent to Docs API - no file {file_data}",
-#     file_data=["name", "mimetype", "source"],
-# )
-# def case_bad_data_file(file_data) -> CaseData:
-#
-#     default_test_data = {
-#         "report": {
-#             "data": {
-#                 "type": "reports",
-#                 "attributes": {
-#                     "submission_id": 12345,
-#                     "reporting_period_from": "2019-01-01",
-#                     "reporting_period_to": "2019-12-31",
-#                     "year": 2019,
-#                     "date_submitted": "2020-01-03T09:30:00.001Z",
-#                     "type": "PF",
-#                 },
-#                 "file": {
-#                     "name": "Report_1234567T_2018_2019_11111.pdf",
-#                     "mimetype": "application/pdf",
-#                     "source": "string",
-#                 },
-#             }
-#         }
-#     }
-#
-#     test_data = copy.deepcopy(default_test_data)
-#     del test_data["report"]["data"]["file"][file_data]
-#
-#     test_case_ref = 1111
-#
-#     test_headers = {"Content-Type": "application/json"}
-#
-#     expected_response_status_code = 400
-#     expected_response_data = "unable to parse payload"
-#
-#     return (
-#         test_data,
-#         test_headers,
-#         test_case_ref,
-#         expected_response_status_code,
-#         expected_response_data,
-#     )
-
-
+@pytest.mark.xfail(reason="No error handling around DIGIDEPS_S3_BUCKET")
 @case_tags("environment")
 @cases_generator(
-    "Missing environment variables - {ev}", ev=["SIRIUS_BASE_URL", "SIRIUS_API_VERSION"]
+    "Missing environment variables - {ev}",
+    ev=["SIRIUS_BASE_URL", "API_VERSION", "DIGIDEPS_S3_BUCKET"],
 )
 def case_missing_env_vars(ev) -> CaseData:
 

--- a/lambda_functions/v2/tests/routes/cases_supporting_docs_endpoint.py
+++ b/lambda_functions/v2/tests/routes/cases_supporting_docs_endpoint.py
@@ -1,6 +1,8 @@
-from pytest_cases import case_name, CaseData
+import pytest
+from pytest_cases import case_name, CaseData, case_tags
 
 
+@case_tags("endpoint", "success")
 @case_name("Successful post to supporting docs endpoint")
 def case_success() -> CaseData:
 
@@ -31,6 +33,126 @@ def case_success() -> CaseData:
             "type": "supportingdocuments",
         }
     }
+
+    return (
+        test_data,
+        test_headers,
+        test_report_id,
+        test_case_ref,
+        expected_response_status_code,
+        expected_response_data,
+    )
+
+
+@case_tags("endpoint", "success")
+@case_name("Successful post to supporting docs endpoint using s3 ref")
+def case_success_s3() -> CaseData:
+
+    test_data = {
+        "supporting_document": {
+            "data": {
+                "type": "supportingdocuments",
+                "attributes": {"submission_id": 12345},
+                "file": {
+                    "name": "Report_1234567T_2018_2019_11111.pdf",
+                    "mimetype": "application/pdf",
+                    "s3_reference": "this_is_a_file_on_s3.pdf",
+                },
+            }
+        }
+    }
+    test_case_ref = 1111
+    test_report_id = "de26f80c-ed6d-4c52-b6bd-e0260bb0faf0"
+
+    test_headers = {"Content-Type": "application/json"}
+
+    expected_response_status_code = 201
+    expected_response_data = {
+        "data": {
+            "attributes": {"submission_id": 12345, "parent_id": None},
+            "id": "5a8b1a26-8296-4373-ae61-f8d0b250e773",
+            # "type": "Report - General",
+            "type": "supportingdocuments",
+        }
+    }
+
+    return (
+        test_data,
+        test_headers,
+        test_report_id,
+        test_case_ref,
+        expected_response_status_code,
+        expected_response_data,
+    )
+
+
+@case_tags("endpoint", "success")
+@case_name("Successful post to supporting docs endpoint with both source and s3 ref")
+def case_success_s3_and_source() -> CaseData:
+
+    test_data = {
+        "supporting_document": {
+            "data": {
+                "type": "supportingdocuments",
+                "attributes": {"submission_id": 12345},
+                "file": {
+                    "name": "Report_1234567T_2018_2019_11111.pdf",
+                    "mimetype": "application/pdf",
+                    "source": "string",
+                    "s3_reference": "this_is_a_file_on_s3.pdf",
+                },
+            }
+        }
+    }
+    test_case_ref = 1111
+    test_report_id = "de26f80c-ed6d-4c52-b6bd-e0260bb0faf0"
+
+    test_headers = {"Content-Type": "application/json"}
+
+    expected_response_status_code = 201
+    expected_response_data = {
+        "data": {
+            "attributes": {"submission_id": 12345, "parent_id": None},
+            "id": "5a8b1a26-8296-4373-ae61-f8d0b250e773",
+            # "type": "Report - General",
+            "type": "supportingdocuments",
+        }
+    }
+
+    return (
+        test_data,
+        test_headers,
+        test_report_id,
+        test_case_ref,
+        expected_response_status_code,
+        expected_response_data,
+    )
+
+
+@pytest.mark.xfail(reason="No error handling")
+@case_tags("endpoint", "error")
+@case_name("Successful post to supporting docs endpoint with neither source or s3 ref")
+def case_error_missing_s3_and_source() -> CaseData:
+
+    test_data = {
+        "supporting_document": {
+            "data": {
+                "type": "supportingdocuments",
+                "attributes": {"submission_id": 12345},
+                "file": {
+                    "name": "Report_1234567T_2018_2019_11111.pdf",
+                    "mimetype": "application/pdf",
+                },
+            }
+        }
+    }
+    test_case_ref = 1111
+    test_report_id = "de26f80c-ed6d-4c52-b6bd-e0260bb0faf0"
+
+    test_headers = {"Content-Type": "application/json"}
+
+    expected_response_status_code = 400
+    expected_response_data = "OPGDATA-API-INVALIDREQUEST"
 
     return (
         test_data,

--- a/lambda_functions/v2/tests/routes/conftest.py
+++ b/lambda_functions/v2/tests/routes/conftest.py
@@ -169,3 +169,22 @@ def patched_send_get_to_sirius_healthcheck(monkeypatch):
     monkeypatch.setattr(
         api.sirius_service, "send_get_to_sirius", mock_send_get_to_sirius
     )
+
+
+@pytest.fixture()
+def patched_s3_client(monkeypatch):
+    def mock_s3_client(*args, **kwargs):
+        print("Mock get_digideps_s3_client")
+        return "valid_client"
+
+    monkeypatch.setattr(api.helpers, "get_digideps_s3_client", mock_s3_client)
+
+
+@pytest.fixture()
+def patched_s3_file(monkeypatch):
+    def mock_s3_file(*args, **kwargs):
+        print("Mock s3_file")
+
+        return "bas64 encoded string"
+
+    monkeypatch.setattr(api.helpers, "get_encoded_s3_object", mock_s3_file)

--- a/lambda_functions/v2/tests/routes/test_report_endpoint.py
+++ b/lambda_functions/v2/tests/routes/test_report_endpoint.py
@@ -8,7 +8,9 @@ from lambda_functions.v2.tests.routes import cases_reports_endpoint
 
 
 @pytest.mark.run(order=1)
-@pytest.mark.usefixtures("patched_get_secret", "patched_post")
+@pytest.mark.usefixtures(
+    "patched_get_secret", "patched_post", "patched_s3_client", "patched_s3_file"
+)
 @cases_data(module=cases_reports_endpoint, has_tag="success")
 def test_reports(server, case_data: CaseDataGetter):
     (
@@ -26,12 +28,18 @@ def test_reports(server, case_data: CaseDataGetter):
             headers=test_headers,
             data=json.dumps(test_data),
         )
-
+        print(f"r.json(): {r.json()}")
+        assert r.status_code == expected_response_status_code
         assert r.json() == expected_response_data
 
 
 @pytest.mark.run(order=1)
-@pytest.mark.usefixtures("patched_get_secret", "patched_post_broken_sirius")
+@pytest.mark.usefixtures(
+    "patched_get_secret",
+    "patched_post_broken_sirius",
+    "patched_s3_client",
+    "patched_s3_file",
+)
 @cases_data(module=cases_reports_endpoint, has_tag="error")
 def test_reports_errors(server, case_data: CaseDataGetter):
     (
@@ -50,5 +58,37 @@ def test_reports_errors(server, case_data: CaseDataGetter):
             data=json.dumps(test_data),
         )
 
+        assert r.status_code == expected_response_status_code
         if r.status_code in [400]:
             assert r.json()["body"]["error"]["code"] == expected_response_data
+
+
+@pytest.mark.run(order=1)
+@pytest.mark.usefixtures(
+    "patched_get_secret",
+    "patched_post_broken_sirius",
+    "patched_s3_client",
+    "patched_s3_file",
+)
+@cases_data(module=cases_reports_endpoint, has_tag="environment")
+def test_reports_environment(server, monkeypatch, caplog, case_data: CaseDataGetter):
+    (
+        env_var,
+        test_data,
+        test_headers,
+        test_case_ref,
+        expected_response_status_code,
+        expected_logger_message,
+    ) = case_data.get()
+
+    monkeypatch.delenv(env_var)
+
+    with server.app_context():
+
+        r = requests.post(
+            f"{server.url}/clients/{test_case_ref}/reports",
+            headers=test_headers,
+            data=json.dumps(test_data),
+        )
+
+        assert r.status_code == expected_response_status_code

--- a/lambda_functions/v2/tests/routes/test_supporting_docs_endpoint.py
+++ b/lambda_functions/v2/tests/routes/test_supporting_docs_endpoint.py
@@ -9,9 +9,13 @@ from lambda_functions.v2.tests.routes import cases_supporting_docs_endpoint
 
 @pytest.mark.run(order=1)
 @pytest.mark.usefixtures(
-    "patched_get_secret", "patched_post", "patched_send_get_to_sirius"
+    "patched_s3_client",
+    "patched_s3_file",
+    "patched_get_secret",
+    "patched_post",
+    "patched_send_get_to_sirius",
 )
-@cases_data(module=cases_supporting_docs_endpoint)
+@cases_data(module=cases_supporting_docs_endpoint, has_tag="success")
 def test_supporting_docs(server, case_data: CaseDataGetter):
     (
         test_data,
@@ -37,3 +41,36 @@ def test_supporting_docs(server, case_data: CaseDataGetter):
 
         assert r.status_code == expected_response_status_code
         assert r.json() == expected_response_data
+
+
+@pytest.mark.run(order=1)
+@pytest.mark.usefixtures(
+    "patched_s3_client", "patched_s3_file", "patched_get_secret", "patched_post"
+)
+@cases_data(module=cases_supporting_docs_endpoint, has_tag="error")
+def test_supporting_docs_errors(server, case_data: CaseDataGetter):
+    (
+        test_data,
+        test_headers,
+        test_report_id,
+        test_case_ref,
+        expected_response_status_code,
+        expected_response_data,
+    ) = case_data.get()
+
+    with server.app_context():
+
+        print(f"test_case_ref: {test_case_ref}")
+        print(f"test_report_id: {test_report_id}")
+        print(f"test_data: {test_data}")
+
+        r = requests.post(
+            f"{server.url}/clients/{test_case_ref}/reports/"
+            f"{test_report_id}/supportingdocuments",
+            headers=test_headers,
+            data=json.dumps(test_data),
+        )
+
+        assert r.status_code == expected_response_status_code
+        if r.status_code in [400]:
+            assert r.json()["body"]["error"]["code"] == expected_response_data

--- a/lambda_functions/v2/tests/sirius_service/cases_submit_doc_to_sirius.py
+++ b/lambda_functions/v2/tests/sirius_service/cases_submit_doc_to_sirius.py
@@ -74,10 +74,7 @@ def case_error(test_data) -> CaseData:
     url_params = None
 
     expected_responses = {
-        400: [
-            "Payload validation failed in Sirius",
-            "Could not verify URL params in Sirius",
-        ],
+        400: ["Validation failed in Sirius", "Could not verify URL params in Sirius"],
         500: ["Unable to send document to Sirius", "Unknown error talking to Sirius"],
     }
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -13,5 +13,6 @@ env =
     SIRIUS_BASE_URL=http://not-really-sirius.com
     SESSION_DATA=publicapi@opgtest.com
     JWT_SECRET=THIS_IS_MY_SECRET_KEY
+    DIGIDEPS_S3_BUCKET=valid_bucket
 markers =
     smoke_test: these tests hit the real endpoints and should not be run in CI, will fail locally if you've not got your AWS creds set properly


### PR DESCRIPTION
## Purpose

Move the changes for s3 into v2 

## Approach

I did a diff on every file from IN-235 `flask_app` and `tests/flask_app` and moved any changes over to the equivalent v2 files.

## Learning



## Checklist

* [x] I have performed a self-review of my own code
* [x] I have added relevant logging with appropriate levels to my code
* [x] I have updated documentation where relevant
* [x] I have added tests to prove my work
* [ ] The product team have tested these changes
* [x] I have run the integration tests (results below)

Bear in mind the integration tests DO NOT currently try to send a file to Sirius using an s3 ref
![image](https://user-images.githubusercontent.com/6086996/88141484-9a051980-cbeb-11ea-9dee-8cf036e23daf.png)

