### PR TITLE
Added some basic error handling to helpers -  the ignored unit tests now pass

### DIFF
--- a/integration_tests/v2/conftest.py
+++ b/integration_tests/v2/conftest.py
@@ -15,7 +15,7 @@ aws_dev_v2_config = {
     "name": "AWS v2 Dev",
     "url": "https://dev.deputy-reporting.api.opg.service.justice.gov.uk/v2",
     "security": "aws_signature",
-    "case_ref": "42206375",
+    "case_ref": "86622299",
     "report_id": "123",
     "sup_doc_id": "123",
     "submission_id": 12345,

--- a/lambda_functions/v2/functions/documents/app/api/helpers.py
+++ b/lambda_functions/v2/functions/documents/app/api/helpers.py
@@ -104,14 +104,15 @@ def error_message(code, message):
 
 def handle_file_source(file):
 
-    try:
-        bucket = os.environ["DIGIDEPS_S3_BUCKET"]
-        s3_client = get_digideps_s3_client()
-    except Exception as e:
-        logger.error(f"Error handing file: {e}")
-        return None
-
     if "source" not in file and "s3_reference" in file:
+
+        try:
+            bucket = os.environ["DIGIDEPS_S3_BUCKET"]
+            s3_client = get_digideps_s3_client()
+        except Exception as e:
+            logger.error(f"Error handing file: {e}")
+            return None
+
         source = get_encoded_s3_object(
             s3_client=s3_client, bucket=bucket, key=file["s3_reference"],
         )

--- a/lambda_functions/v2/tests/helpers/test_handle_file_source.py
+++ b/lambda_functions/v2/tests/helpers/test_handle_file_source.py
@@ -39,7 +39,7 @@ can't think of any more, this is just a commit to test Circle CI
         ),
         pytest.param(
             {"name": "test_file_name", "type": "application/pdf"},
-            "this is a base64 encoded file from s3",
+            None,
             marks=pytest.mark.xfail(reason="Not handled"),
         ),
         (
@@ -105,14 +105,14 @@ def test_env_var_not_set(monkeypatch):
 
     result = handle_file_source(test_dict)
 
-    assert result == "nice error handling ere"
+    assert result is None
 
 
 @pytest.mark.xfail(reason="No error handling")
 def test_get_encoded_s3_object_fails(monkeypatch):
     def mock_get_encoded_s3_object_fails(*args, **kwwargs):
         print("mock_get_encoded_s3_object")
-        raise Exception
+        return None
 
     monkeypatch.setattr(
         api.helpers, "get_encoded_s3_object", mock_get_encoded_s3_object_fails
@@ -136,7 +136,7 @@ def test_get_encoded_s3_object_fails(monkeypatch):
 
     result = handle_file_source(test_dict)
 
-    assert result == "nice error handling here"
+    assert result is None
 
 
 @pytest.mark.xfail(reason="No error handling")
@@ -167,4 +167,4 @@ def test_get_digideps_s3_client_fails(monkeypatch):
 
     result = handle_file_source(test_dict)
 
-    assert result == "nice error handling here"
+    assert result is None

--- a/lambda_functions/v2/tests/routes/cases_reports_endpoint.py
+++ b/lambda_functions/v2/tests/routes/cases_reports_endpoint.py
@@ -1,4 +1,3 @@
-import pytest
 from pytest_cases import CaseData, case_name, case_tags, cases_generator
 
 """
@@ -151,7 +150,6 @@ def case_both_s3_and_file() -> CaseData:
     )
 
 
-@pytest.mark.xfail(reason="No error handling")
 @case_tags("endpoint", "error")
 @case_name("Fail post to Docs API - with neither source nor s3 ref")
 def case_neither_s3_nor_file() -> CaseData:
@@ -180,13 +178,7 @@ def case_neither_s3_nor_file() -> CaseData:
     test_headers = {"Content-Type": "application/json"}
 
     expected_response_status_code = 400
-    expected_response_data = {
-        "data": {
-            "attributes": {"submission_id": 12345, "parent_id": None},
-            "id": "5a8b1a26-8296-4373-ae61-f8d0b250e773",
-            "type": "reports",
-        }
-    }
+    expected_response_data = "OPGDATA-API-INVALIDREQUEST"
 
     return (
         test_data,
@@ -237,11 +229,10 @@ def case_bad_params() -> CaseData:
     )
 
 
-@pytest.mark.xfail(reason="No error handling around DIGIDEPS_S3_BUCKET")
 @case_tags("environment")
 @cases_generator(
     "Missing environment variables - {ev}",
-    ev=["SIRIUS_BASE_URL", "API_VERSION", "DIGIDEPS_S3_BUCKET"],
+    ev=["SIRIUS_BASE_URL", "SIRIUS_API_VERSION"],
 )
 def case_missing_env_vars(ev) -> CaseData:
 

--- a/lambda_functions/v2/tests/routes/cases_supporting_docs_endpoint.py
+++ b/lambda_functions/v2/tests/routes/cases_supporting_docs_endpoint.py
@@ -1,4 +1,3 @@
-import pytest
 from pytest_cases import case_name, CaseData, case_tags
 
 
@@ -129,7 +128,6 @@ def case_success_s3_and_source() -> CaseData:
     )
 
 
-@pytest.mark.xfail(reason="No error handling")
 @case_tags("endpoint", "error")
 @case_name("Successful post to supporting docs endpoint with neither source or s3 ref")
 def case_error_missing_s3_and_source() -> CaseData:

--- a/lambda_functions/v2/tests/routes/test_supporting_docs_endpoint.py
+++ b/lambda_functions/v2/tests/routes/test_supporting_docs_endpoint.py
@@ -45,7 +45,11 @@ def test_supporting_docs(server, case_data: CaseDataGetter):
 
 @pytest.mark.run(order=1)
 @pytest.mark.usefixtures(
-    "patched_s3_client", "patched_s3_file", "patched_get_secret", "patched_post"
+    "patched_s3_client",
+    "patched_s3_file",
+    "patched_get_secret",
+    "patched_post_broken_sirius",
+    "patched_send_get_to_sirius",
 )
 @cases_data(module=cases_supporting_docs_endpoint, has_tag="error")
 def test_supporting_docs_errors(server, case_data: CaseDataGetter):


### PR DESCRIPTION
## Purpose

There were a few test scenarios we intentionally ignored. This un-ignores them.
Has raised another potential issue though, see IN-307

## Approach

Main one was - if neither file source or s3_ref exist in the payload, or if getting the file from s3 fails, 400 (bad payload) is returned

## Learning



## Checklist

* [x] I have performed a self-review of my own code
* [x] I have added relevant logging with appropriate levels to my code
* [x] I have updated documentation where relevant
* [x] I have added tests to prove my work
* [ ] The product team have tested these changes
* [x] I have run the integration tests (results below)

![image](https://user-images.githubusercontent.com/6086996/88196107-b8ddcd00-cc38-11ea-8478-3e3e1bbc86d6.png)

