### PR TITLE
Fix string interpolation in openapi spec

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -323,6 +323,11 @@ jobs:
           command: |
             eval $(cat $BASH_ENV)
       - run:
+          name: modify openapispec
+          command:
+            sed -i "s/\"\${allowed_roles}\"/\${allowed_roles}/" deputy-reporting-openapi.yml
+          working_directory: ~/project/lambda_functions/v2/openapi
+      - run:
           name: terraform << parameters.tf_command >> - environment
           command: terraform << parameters.tf_command >>
           working_directory: ~/project/terraform/environment

--- a/lambda_functions/v2/openapi/deputy-reporting-openapi.yml
+++ b/lambda_functions/v2/openapi/deputy-reporting-openapi.yml
@@ -91,7 +91,7 @@ x-amazon-apigateway-gateway-responses:
         {
             "Effect": "Allow",
             "Principal": {
-              "AWS": [${allowed_roles}]
+              "AWS": []
             },
             "Action": "execute-api:Invoke",
             "Resource": [

--- a/lambda_functions/v2/openapi/deputy-reporting-openapi.yml
+++ b/lambda_functions/v2/openapi/deputy-reporting-openapi.yml
@@ -91,7 +91,7 @@ x-amazon-apigateway-gateway-responses:
         {
             "Effect": "Allow",
             "Principal": {
-              "AWS": []
+              "AWS": ["${allowed_roles}"]
             },
             "Action": "execute-api:Invoke",
             "Resource": [

--- a/mock_integration_rest_api/getopenapidoc
+++ b/mock_integration_rest_api/getopenapidoc
@@ -1,7 +1,4 @@
 #!/bin/bash
 cp ../lambda_functions/v2/openapi/deputy-reporting-openapi.yml .
-sed "s/\${allowed_roles}/'allowed_roles'/" deputy-reporting-openapi.yml > deputy-reporting-openapi.yml.new
-mv deputy-reporting-openapi.yml deputy-reporting-openapi.yml.bak
-mv deputy-reporting-openapi.yml.new deputy-reporting-openapi.yml
-rm deputy-reporting-openapi.yml.bak
+
 echo "copied in v2"


### PR DESCRIPTION
## Purpose
Fixing the policy string interpolation as its not valid yml/openapi spec. Digideps relies on this file to build a mock sirius integration in our environments so this needs to be valid to allow the ECS services to build.




