### PR TITLE
DDPB-4570 create less noisy 5xx alarms

### DIFF
--- a/infrastructure/environment/alerts.tf
+++ b/infrastructure/environment/alerts.tf
@@ -109,3 +109,16 @@ resource "aws_cloudwatch_metric_alarm" "s3_error" {
   alarm_actions       = [data.aws_sns_topic.deputy_reporting_slack.arn]
   tags                = local.default_tags
 }
+
+resource "aws_cloudwatch_log_metric_filter" "api_gateway_supporting_errors" {
+  name           = "deputy-reporting-gateway-supporting-errors.${local.environment}"
+  pattern        = "\"\\\"status\\\":\\\"5\" \"\\\"resourcePath\\\":\\\"/clients/{caseref}/reports/{id}/supportingdocuments\\\"\""
+  log_group_name = "API-Gateway-Execution-Logs-deputy-reporting-${local.environment}-v2"
+
+  metric_transformation {
+    name          = "DeputyReportingSupportingDoc500.${local.environment}"
+    namespace     = "ApiGateway"
+    value         = "1"
+    default_value = "0"
+  }
+}


### PR DESCRIPTION
## Purpose

Noisy alarm that only tells us a healthcheck has failed intermittently which doesn't seem to effect anything and muddies the dev channel.

## Approach

Put up the limit for straight 5xx errors failing so that it would only notify us if sirius is really down for 3 minutes.

Add in separate metrics and alarms based on pattern matching for each of the document types that can fail and set it to trigger on a single fail in prod as we probably do want to know about these.

Looks like this:

<img width="649" alt="image" src="https://user-images.githubusercontent.com/58939809/203332886-9e713ec9-c1db-4bef-97fa-9d3738a7baf8.png">


## Learning

https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/FilterAndPatternSyntax.html

API logs in weird in between format that isn't really json or space delimited so it's a bit more annoying to filter...

## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation where relevant
* [ ] I have added tests to prove my work
* [ ] The product team have tested these changes
* [ ] I have run the integration tests (results below)


