### PR TITLE
DDPB-4575 add renovate config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,64 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:base",
+    "schedule:earlyMondays"
+  ],
+  "branchPrefix": "renovate-",
+  "commitMessageAction": "Renovate Update",
+  "labels": [
+    "Dependencies",
+    "Renovate"
+  ],
+  "packageRules": [
+    {
+      "groupName": "Patch & Minor Updates",
+      "groupSlug": "all-minor-patch-updates",
+      "labels": [
+        "Dependencies",
+        "Renovate"
+      ],
+      "matchPackagePatterns": [
+        "*"
+      ],
+      "matchUpdateTypes": [
+        "minor",
+        "patch"
+      ],
+      "prPriority": 0,
+      "schedule": [
+        "after 6am and before 7am on Monday"
+      ],
+      "stabilityDays": 3
+    }
+  ],
+  "major": {
+    "labels": [
+        "Dependencies",
+        "Renovate"
+    ],
+    "prCreation": "status-success",
+    "rangeStrategy": "pin",
+    "prPriority": 1,
+    "schedule": [
+      "after 6am and before 7am on Monday"
+    ]
+  },
+  "vulnerabilityAlerts": {
+    "groupName": "Security Alerts",
+    "labels": [
+      "Dependencies",
+      "Renovate"
+    ],
+    "schedule": [
+      "after 6am and before 7am every weekday"
+    ],
+    "dependencyDashboardApproval": false,
+    "stabilityDays": 0,
+    "rangeStrategy": "pin",
+    "commitMessagePrefix": "[SECURITY]",
+    "branchTopic": "{{{datasource}}}-{{{depName}}}-vulnerability",
+    "prCreation": "immediate",
+    "prPriority": 5
+  }
+}


### PR DESCRIPTION
## Purpose

Trial renovate

## Approach

I think this config makes sense from reading the docs but will have to see that it works as intended. The idea is group minor and patch updates into one PR but have major and vulnerabilities as separate PRs that checks daily.

## Learning
NA

## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation where relevant
* [ ] I have added tests to prove my work
* [ ] The product team have tested these changes
* [ ] I have run the integration tests (results below)


