### PR TITLE
DDPB-4583 shorten branch name

### DIFF
--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -53,7 +53,7 @@ jobs:
 
       - uses: unfor19/install-aws-cli-action@v1
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@67fbcbb121271f7775d2e7715933280b06314838 # pin@v1.7.0
+        uses: aws-actions/configure-aws-credentials@67fbcbb121271f7775d2e7715933280b06314838
         with:
           aws-access-key-id: ${{ secrets.aws_access_key_id_actions }}
           aws-secret-access-key: ${{ secrets.aws_secret_access_key_actions }}

--- a/.github/workflows/pr_workflow.yml
+++ b/.github/workflows/pr_workflow.yml
@@ -85,7 +85,7 @@ jobs:
         shell: bash
         run: |
           echo "branch_raw=$(echo ${GITHUB_HEAD_REF:-${GITHUB_REF##*/}})" >> $GITHUB_OUTPUT
-          echo "branch_formatted=$(echo ${GITHUB_HEAD_REF:-${GITHUB_REF##*/}} | tr -cd '[:alnum:]' | tr '[:upper:]' '[:lower:]')" >> $GITHUB_OUTPUT
+          echo "branch_formatted=$(echo ${GITHUB_HEAD_REF:-${GITHUB_REF##*/}} | tr -cd '[:alnum:]' | tr '[:upper:]' '[:lower:]' | cut -b 1-12)" >> $GITHUB_OUTPUT
         id: extract_branch
 
   create_tags:

--- a/.github/workflows/scheduled_destroy.yml
+++ b/.github/workflows/scheduled_destroy.yml
@@ -21,15 +21,15 @@ jobs:
   terraform_environment_cleanup:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@bf085276cecdb0cc76fbbe0687a5a0e786646936 # pin@v3
-      - uses: unfor19/install-aws-cli-action@35a9630be0168293ad2afccbe06e8e9f47678d2c # pin@v1.0.3
-      - uses: hashicorp/setup-terraform@17d4c9b8043b238f6f35641cdd8433da1e6f3867 # pin@v2
+      - uses: actions/checkout@bf085276cecdb0cc76fbbe0687a5a0e786646936
+      - uses: unfor19/install-aws-cli-action@35a9630be0168293ad2afccbe06e8e9f47678d2c
+      - uses: hashicorp/setup-terraform@17d4c9b8043b238f6f35641cdd8433da1e6f3867
         with:
           terraform_version: 1.2.6
           terraform_wrapper: false
 
       - name: Configure AWS Credentials For Terraform
-        uses: aws-actions/configure-aws-credentials@67fbcbb121271f7775d2e7715933280b06314838 # pin@v1.7.0
+        uses: aws-actions/configure-aws-credentials@67fbcbb121271f7775d2e7715933280b06314838
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID_ACTIONS }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY_ACTIONS }}

--- a/.github/workflows/terraform_job.yml
+++ b/.github/workflows/terraform_job.yml
@@ -34,12 +34,12 @@ jobs:
 
       - uses: unfor19/install-aws-cli-action@v1
 
-      - uses: hashicorp/setup-terraform@17d4c9b8043b238f6f35641cdd8433da1e6f3867 # pin@v2
+      - uses: hashicorp/setup-terraform@17d4c9b8043b238f6f35641cdd8433da1e6f3867
         with:
           terraform_version: 1.2.6
 
       - name: Configure AWS Credentials For Terraform
-        uses: aws-actions/configure-aws-credentials@67fbcbb121271f7775d2e7715933280b06314838 # pin@v1.7.0
+        uses: aws-actions/configure-aws-credentials@67fbcbb121271f7775d2e7715933280b06314838
         with:
           aws-access-key-id: ${{ secrets.aws_access_key_id_actions }}
           aws-secret-access-key: ${{ secrets.aws_secret_access_key_actions }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 ---
 repos:
-  - repo: git://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.56.0
+  - repo: https://github.com/antonbabenko/pre-commit-terraform
+    rev: v1.72.1
     hooks:
       - id: terraform_fmt
       - id: terraform_validate
@@ -39,4 +39,4 @@ repos:
       - id: golangci-lint
       - id: go-unit-tests
       - id: go-build
-      - id: go-mod-tidy
+#      - id: go-mod-tidy


### PR DESCRIPTION
## Purpose

Shorten branch names

## Approach

- Long branch names breaking terraform plans. Shorten to max 12 chars.
- Also removed the pinning comments as they no longer become valid with renovates updates
- updated version of tf and tf pre commit


