### PR TITLE
DDPB-4582 add failed sirius requests to logs

### DIFF
--- a/lambda_functions/v2/functions/documents/app/api/sirius_service.py
+++ b/lambda_functions/v2/functions/documents/app/api/sirius_service.py
@@ -190,7 +190,7 @@ def new_submit_document_to_sirius(
         )
     except Exception as e:
         return handle_sirius_error(
-            error_message="Unable to send " "document to " "Sirius",
+            error_message="Unable to send document to Sirius",
             error_details=e,
             data=debug_payload,
         )
@@ -247,6 +247,7 @@ def handle_sirius_error(
         )
 
     message = f"{str(error_details)}"
+    logger.error(f"Failed sirius request data - {str(data)}")
 
     return error_code, message
 


### PR DESCRIPTION
## Purpose

Add the request to sirius to logs on failure

## Approach

We did have this before but when sanitising the logging for this service, it got removed. Need it to be able to work out why a handful of checklists are failing.

## Checklist

* [x] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation where relevant
* [ ] I have added tests to prove my work
* [ ] The product team have tested these changes
* [ ] I have run the integration tests (results below)


