### PR TITLE
fix the pipe from broken versioning

### DIFF
--- a/.github/workflows/tags_job.yml
+++ b/.github/workflows/tags_job.yml
@@ -22,7 +22,7 @@ jobs:
           fetch-depth: 0
       - name: Install semver
         id: install_semver
-        run: sudo apt install node-semver
+        run: sudo npm install -g semver
 
       - name: Bump version
         id: bump_version


### PR DESCRIPTION
Use npm semver instead so dependencies don't cause issues from using apt.