### PR TITLE
Remove aquasecurity/trivy-action from .github/workflows/_docker_build.yml

### DIFF
--- a/.github/workflows/_docker_build.yml
+++ b/.github/workflows/_docker_build.yml
@@ -62,18 +62,9 @@ jobs:
 
       - name: trivy image scanning
         id: trivy_scan
-        uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8 # 0.33.1
-        with:
-          image-ref: ${{ matrix.name }}:latest
-          severity: "HIGH,CRITICAL"
-          format: "sarif"
-          scanners: "vuln"
-          output: "trivy-results.sarif"
-          timeout: 15m
-        env:
-          TRIVY_DB_REPOSITORY: ${{ steps.login_ecr.outputs.registry }}/trivy-db-public-ecr/aquasecurity/trivy-db
-          TRIVY_JAVA_DB_REPOSITORY: ${{ steps.login_ecr.outputs.registry }}/trivy-db-public-ecr/aquasecurity/trivy-java-db
-
+        run: |
+          echo '{"version":"2.1.0","$schema":"https://json.schemastore.org/sarif-2.1.0.json","runs":[]}' > 'trivy-results.sarif'
+          echo 'trivy-action step removed — created empty SARIF stub'
       - name: upload trivy scan results to security tab
         if: matrix.name != 'deputy-reporting-mock-sirius'
         id: trivy_upload_sarif


### PR DESCRIPTION
## Why

`aquasecurity/trivy-action` has been compromised for the second time. All tags before `0.35.0` were re-pointed to a malicious commit that **dumps process memory to steal credentials** from CI runners.

- **Issue:** https://github.com/aquasecurity/trivy-action/issues/541
- **Exposure window (UTC):** 2026-03-19 ~17:43 – 2026-03-20 ~05:40
- **Malicious commit:** `aquasecurity/setup-trivy@8afa9b9`
- **Details:** https://www.stepsecurity.io/blog/trivy-compromised-a-second-time---malicious-v0-69-4-release

As [recommended by the maintainers](https://github.com/aquasecurity/trivy-action/issues/541#issuecomment-2737987938):

> "As hard as it may be: do not use Trivy anymore for now."

Any repository that ran a workflow using this action during the exposure window may have had secrets exfiltrated. **Rotate any secrets that were available to workflows using this action.**

## What this PR does

Removes the `aquasecurity/trivy-action` step(s) from this workflow. The `uses:` directive and its `with:` block have been replaced with a `run:` step that creates an empty but valid SARIF file (where applicable), so downstream steps (e.g. `upload-sarif`) continue to pass.

> **Note:** Repo owners should review whether the entire workflow/job can now be removed, or whether an alternative scanning solution should be adopted.

Raised automatically for review.
