### PR TITLE
use new less privileged integration test role

### DIFF
--- a/.github/workflows/workflow_pull_request.yml
+++ b/.github/workflows/workflow_pull_request.yml
@@ -135,7 +135,7 @@ jobs:
       environment_prefix: '${{ needs.workflow_variables.outputs.build_identifier }}.dev.'
       digideps_account: 248804316466
       sirius_account: 288342028542
-      role: 'healthcheck-integration'
+      role: ''
 
   terraform_plan_development_account:
     name: Terraform Plan Development Account

--- a/.github/workflows/workflow_pull_request.yml
+++ b/.github/workflows/workflow_pull_request.yml
@@ -135,7 +135,7 @@ jobs:
       environment_prefix: '${{ needs.workflow_variables.outputs.build_identifier }}.dev.'
       digideps_account: 248804316466
       sirius_account: 288342028542
-      role: ''
+      role: 'healthcheck-integration'
 
   terraform_plan_development_account:
     name: Terraform Plan Development Account

--- a/integration_tests/v2/conftest.py
+++ b/integration_tests/v2/conftest.py
@@ -68,7 +68,11 @@ def pytest_sessionfinish(session, exitstatus):
         teardown_test_doc(test_config=test_config)
 
 
-def get_role_name():
+def get_digideps_role_name():
+    return "deputy-reporting-integration" if os.getenv("CI") == "true" else "operator"
+
+
+def get_sirius_role_name():
     return "integrations-ci" if os.getenv("CI") == "true" else "operator"
 
 
@@ -110,7 +114,7 @@ def assume_session(
 def upload_test_doc(test_config):
     session = assume_session(
         "assumed_role_session",
-        f"arn:aws:iam::248804316466:role/{get_role_name()}",
+        f"arn:aws:iam::248804316466:role/{get_digideps_role_name()}",
         region_name=test_config["aws_region"],
     )
     s3_client = session.client(service_name="s3")
@@ -127,7 +131,7 @@ def upload_test_doc(test_config):
 def teardown_test_doc(test_config):
     session = assume_session(
         "assumed_role_session",
-        f"arn:aws:iam::248804316466:role/{get_role_name()}",
+        f"arn:aws:iam::248804316466:role/{get_digideps_role_name()}",
         region_name=test_config["aws_region"],
     )
     s3_resource = session.resource(service_name="s3")
@@ -167,7 +171,7 @@ def send_a_request(
 
     session = assume_session(
         "assumed_role_session",
-        f"arn:aws:iam::288342028542:role/{get_role_name()}",
+        f"arn:aws:iam::288342028542:role/{get_sirius_role_name()}",
         region_name=test_config["aws_region"],
     )
     credentials = session.get_credentials()

--- a/scripts/smoke/smoke_test.go
+++ b/scripts/smoke/smoke_test.go
@@ -64,6 +64,9 @@ func TestHealthCheck(t *testing.T) {
 	if finalRole != "" {
 		finalRoleToAssume = fmt.Sprintf("arn:aws:iam::%s:role/%s", digidepsAccountId, finalRole)
 	}
+
+	fmt.Println(baseRoleToAssume)
+	fmt.Println(finalRoleToAssume)
 	// URL for the health check endpoint
 	url := fmt.Sprintf("https://%sdeputy-reporting.api.opg.service.justice.gov.uk/v2/healthcheck", environmentPrefix)
 


### PR DESCRIPTION
As part of downgrading permissions for our roles we have managed to remove some admin roles and replace with a much less privileged role for the integration tests. 

I have printed the roles for healthcheck too as it was unclear whilst debugging which roles were being assumed. 