### PR TITLE
DDLS-1380 Digideps now sends dd report type and court order UIDs with report PDF

### DIFF
--- a/.github/.snyk
+++ b/.github/.snyk
@@ -9,3 +9,11 @@ ignore:
           patching vendor dependencies. Runtime usage does not expose
           lodash template execution paths.
         expires: 2026-09-01
+
+  SNYK-JS-UUID-16133035:
+    - '*':
+        reason: >
+          Vulnerability originates from transitive dependency in
+          stoplight/prism base image (@stoplight/http-spec).
+          Runtime usage does not expose uuid generation paths.
+        expires: 2026-08-13

--- a/lambda_functions/v2/openapi/deputy-reporting-openapi.yml
+++ b/lambda_functions/v2/openapi/deputy-reporting-openapi.yml
@@ -627,6 +627,8 @@ components:
             - year
             - date_submitted
             - type
+            - digideps_report_type
+            - court_order_uids
           properties:
             submission_id:
               $ref: '#/components/schemas/submissionId'
@@ -641,6 +643,10 @@ components:
               example: "2020-01-03T09:30:00.001Z"
             type:
               $ref: '#/components/schemas/reportType'
+            digideps_report_type:
+              $ref: '#/components/schemas/digidepsReportType'
+            court_order_uids:
+              $ref: '#/components/schemas/courtOrderUids'
         file:
           $ref: '#/components/schemas/file'
     ReportChecklist:
@@ -725,6 +731,32 @@ components:
         - "NDR"
         - "COMBINED"
       example: "PF"
+    digidepsReportType:
+      type: string
+      description: "The report type as decided by Digideps: '-4' => hybrid; '-5' => PRO; '-6' => PA"
+      enum:
+        - "102"
+        - "103"
+        - "104"
+        - "102-4"
+        - "103-4"
+        - "104-4"
+        - "102-5"
+        - "103-5"
+        - "104-5"
+        - "102-4-5"
+        - "103-4-5"
+        - "102-6"
+        - "103-6"
+        - "104-6"
+        - "102-4-6"
+        - "103-4-6"
+    courtOrderUids:
+      type: array
+      description: "List of court order UIDs relating to the report submission; these correspond to Sirius court order UIDs"
+      items:
+        type: string
+      example: ["70605948", "70605949"]
     file:
       type: object
       required:

--- a/lambda_functions/v2/openapi/deputy-reporting-openapi.yml
+++ b/lambda_functions/v2/openapi/deputy-reporting-openapi.yml
@@ -627,8 +627,6 @@ components:
             - year
             - date_submitted
             - type
-            - digideps_report_type
-            - court_order_uids
           properties:
             submission_id:
               $ref: '#/components/schemas/submissionId'

--- a/mock_sirius/Dockerfile
+++ b/mock_sirius/Dockerfile
@@ -1,5 +1,8 @@
 FROM stoplight/prism:5.15.10@sha256:586d1f0f94f8d0eaf20b26b8b41f985f2a2d494bea297bd3988c3de3eb87094e
 
+RUN cd /usr/src/prism/; \
+    npm install fast-uri@^3.1.1
+
 # Get rid of NPM entirely as not needed after install
 RUN set -eux; \
     rm -rf /usr/local/lib/node_modules/npm; \


### PR DESCRIPTION
## Purpose

[DDLS-1380](https://opgtransform.atlassian.net/browse/DDLS-1380) - deputy integration side of the changes to include court order UIDs and digideps report type with report PDF payloads forwarded to Sirius.

## Approach

_Explain how your code addresses the purpose of the change_

## Learning

_Any tips and tricks, blog posts or tools which helped you. Plus anything notable you've discovered_

## Checklist

* [ ] I have performed a self-review of my own code
* [ ] I have added relevant logging with appropriate levels to my code
* [ ] I have updated documentation where relevant
* [ ] I have added tests to prove my work
* [ ] The product team have tested these changes
* [ ] I have run the integration tests (results below)




[DDLS-1380]: https://opgtransform.atlassian.net/browse/DDLS-1380?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ