### PR TITLE
Integration env no longer exists

### DIFF
--- a/infrastructure/environment/terraform.tfvars.json
+++ b/infrastructure/environment/terraform.tfvars.json
@@ -27,9 +27,7 @@
       "account_mapping": "preproduction",
       "allowed_roles": [
         "arn:aws:iam::454262938596:role/front.preproduction",
-        "arn:aws:iam::454262938596:role/front.integration",
         "arn:aws:iam::454262938596:role/sirius-files-sync.preproduction",
-        "arn:aws:iam::454262938596:role/sirius-files-sync.integration",
         "arn:aws:iam::492687888235:role/synthetics-preproduction"
       ],
       "digideps_account_id": "454262938596",


### PR DESCRIPTION
This environment no longer exists so it can't find the roles. It was replaced with staging and I have just cleared up some of the old resources from this environment.